### PR TITLE
Fix Kaimon detection on Windows: _kaimon_dir() now matches kaimon_config_dir()

### DIFF
--- a/src/KaimonSlate.jl
+++ b/src/KaimonSlate.jl
@@ -50,10 +50,17 @@ export serve_notebook, LiveNotebook, expand, standalone!, register_extension
 # launches Kaimon and opens the browser. No hand-editing of config, no manual
 # `serve_notebook`. Detection is simply "Kaimon's config dir exists".
 
-# Kaimon's config dir. Mirrors Kaimon's own `kaimon_config_dir()` — respects `XDG_CONFIG_HOME` so a
-# notebook launched with an isolated config (e.g. a headless "run this live" instance) registers into
-# THAT config, not the user's real `~/.config/kaimon`. A function (not a const) so it re-reads ENV.
-_kaimon_dir() = joinpath(get(ENV, "XDG_CONFIG_HOME", joinpath(homedir(), ".config")), "kaimon")
+# Kaimon's config dir. Mirrors Kaimon's own `kaimon_config_dir()`: `%APPDATA%\Kaimon` on Windows,
+# `~/.config/kaimon` elsewhere. An explicit `XDG_CONFIG_HOME` takes precedence on every platform so a
+# notebook launched with an isolated config (e.g. a headless "run this live" instance, or the test
+# suite) registers into THAT config, not the user's real one. A function (not a const) so it re-reads ENV.
+function _kaimon_dir()
+    xdg = get(ENV, "XDG_CONFIG_HOME", "")
+    isempty(xdg) || return joinpath(xdg, "kaimon")
+    Sys.iswindows() &&
+        return joinpath(get(ENV, "APPDATA", joinpath(homedir(), "AppData", "Roaming")), "Kaimon")
+    return joinpath(homedir(), ".config", "kaimon")
+end
 
 # Is `path` a KaimonSlate package checkout? Used to dedup extension entries by IDENTITY rather than
 # by exact path, so a second checkout / git worktree / packaged copy doesn't add a duplicate hub.
@@ -67,7 +74,8 @@ end
 """
     register_extension(; auto_start=true, enabled=true, force=false, project_path=pkgdir(KaimonSlate)) -> Bool
 
-Add this package to Kaimon's extension registry (`~/.config/kaimon/extensions.json`) so Kaimon
+Add this package to Kaimon's extension registry (`extensions.json` in Kaimon's config dir —
+`%APPDATA%\\Kaimon` on Windows, `~/.config/kaimon` elsewhere) so Kaimon
 loads the `slate.*` tools automatically — no hand-wiring. **Idempotent**: returns `false`
 (nothing written) if Kaimon isn't installed here or the entry already exists, and `true` when an
 entry is added. Registration is consented: the `slate` app prompts on first run (see app.jl), and

--- a/test/test_app.jl
+++ b/test/test_app.jl
@@ -29,6 +29,21 @@ _onboard(input::String) = begin
     (ret, String(take!(out)))
 end
 
+@testset "_kaimon_dir platform resolution" begin
+    # explicit XDG_CONFIG_HOME wins on every platform (test isolation depends on this)
+    withenv("XDG_CONFIG_HOME" => "/tmp/xdg-kaimon-test") do
+        @test KS._kaimon_dir() == joinpath("/tmp/xdg-kaimon-test", "kaimon")
+    end
+    # platform default: %APPDATA%\Kaimon on Windows (matching Kaimon's kaimon_config_dir()),
+    # ~/.config/kaimon elsewhere
+    withenv("XDG_CONFIG_HOME" => nothing) do
+        expected = Sys.iswindows() ?
+            joinpath(get(ENV, "APPDATA", joinpath(homedir(), "AppData", "Roaming")), "Kaimon") :
+            joinpath(homedir(), ".config", "kaimon")
+        @test KS._kaimon_dir() == expected
+    end
+end
+
 @testset "slateapp onboarding" begin
     @testset "no Kaimon dir → silent no-op" begin
         _with_isolated_config() do tmp


### PR DESCRIPTION
# Fix Kaimon detection on Windows: `_kaimon_dir()` now matches `kaimon_config_dir()`

## Problem

On Windows, KaimonSlate never detects an installed Kaimon, so the `slate` app's first-run registration prompt never appears and `KaimonSlate.register_extension()` silently returns `false`.

The cause is a platform mismatch between the two packages. Kaimon resolves its config dir per-platform ([`kaimon_config_dir()`](https://github.com/kahliburke/Kaimon.jl/blob/main/src/Kaimon.jl#L87)):

```julia
dir = if Sys.iswindows()
    joinpath(get(ENV, "APPDATA", joinpath(homedir(), "AppData", "Roaming")), "Kaimon")
else
    joinpath(get(ENV, "XDG_CONFIG_HOME", joinpath(homedir(), ".config")), "kaimon")
end
```

…but KaimonSlate's `_kaimon_dir()` only implements the non-Windows branch:

```julia
_kaimon_dir() = joinpath(get(ENV, "XDG_CONFIG_HOME", joinpath(homedir(), ".config")), "kaimon")
```

Since extension detection is simply "Kaimon's config dir exists", a Windows user with a fully working Kaimon (config in `%APPDATA%\Kaimon`) looks like "Kaimon not installed" to KaimonSlate. Slate then falls back to owning its own hub — no `slate.*` tools, no agent.

## Fix

`_kaimon_dir()` now mirrors Kaimon's resolution order, with one deliberate difference: an explicit `XDG_CONFIG_HOME` takes precedence **on every platform**. This preserves isolated-config launches and the test suite's isolation strategy (`test_app.jl` sandboxes both config surfaces via `XDG_CONFIG_HOME`), which would otherwise write into the real `%APPDATA%\Kaimon` when run on Windows.

```julia
function _kaimon_dir()
    xdg = get(ENV, "XDG_CONFIG_HOME", "")
    isempty(xdg) || return joinpath(xdg, "kaimon")
    Sys.iswindows() &&
        return joinpath(get(ENV, "APPDATA", joinpath(homedir(), "AppData", "Roaming")), "Kaimon")
    return joinpath(homedir(), ".config", "kaimon")
end
```

Also updates the `register_extension` docstring, which hard-coded `~/.config/kaimon/extensions.json`.

## Testing

- Added a `_kaimon_dir platform resolution` testset to `test/test_app.jl` covering the `XDG_CONFIG_HOME` override and the per-platform defaults (asserts the `%APPDATA%\Kaimon` path on Windows, `~/.config/kaimon` elsewhere).
- Reproduced on Windows / Julia 1.12 with a working Kaimon install: `register_extension(force=true)` returns `false`, no `extensions.json` is written, and the `slate` app never shows the registration prompt.