### PR TITLE
feat(remote): per-host remote config + rsync --rsync-path + scp -O for locked-down hosts

### DIFF
--- a/src/KaimonSlate.jl
+++ b/src/KaimonSlate.jl
@@ -393,6 +393,24 @@ function _load_slate_config!()
         mkpath(SlateHome.config_home()); write(_slate_config_path(), JSON.json(cfg, 2))
         return nothing
     end
+    # Persist hook for the Remotes modal's per-host settings (rsync_path). Writes
+    # remote.hosts.<host>.<key> in slate.json, prunes emptied entries, and refreshes the live config so a
+    # provision/preflight right after a save uses the new value. Empty rsync_path clears the override.
+    NotebookServer._HOST_CFG_PERSIST[] = function (host, rsync_path)
+        h = String(strip(String(host))); isempty(h) && return nothing
+        cfg = _slate_config()
+        remote = get(cfg, "remote", nothing); remote = remote isa AbstractDict ? Dict{String,Any}(remote) : Dict{String,Any}()
+        hosts  = get(remote, "hosts", nothing); hosts  = hosts  isa AbstractDict ? Dict{String,Any}(hosts)  : Dict{String,Any}()
+        hc     = get(hosts, h, nothing);        hc     = hc     isa AbstractDict ? Dict{String,Any}(hc)     : Dict{String,Any}()
+        rp = String(strip(String(rsync_path)))
+        isempty(rp) ? delete!(hc, "rsync_path") : (hc["rsync_path"] = rp)
+        isempty(hc)    ? delete!(hosts, h)        : (hosts[h] = hc)          # prune an emptied host record
+        isempty(hosts) ? delete!(remote, "hosts") : (remote["hosts"] = hosts)
+        isempty(remote) ? delete!(cfg, "remote")  : (cfg["remote"] = remote)
+        mkpath(SlateHome.config_home()); write(_slate_config_path(), JSON.json(cfg, 2))
+        ReportEngine._REMOTE_CFG[] = remote_config()   # live-refresh: next provision/preflight sees it
+        return nothing
+    end
     return nothing
 end
 

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -109,6 +109,16 @@ h1{color:#fff;font-size:1.3rem;} .empty{color:#6a7090;}
 .rtsteps{font-size:.82rem;}
 .rtnote{color:#6a7090;display:flex;align-items:center;gap:8px;padding:4px 0;}
 .rtnote.err{color:#e57575;}
+.rthelp{display:inline-flex;align-items:center;justify-content:center;width:14px;height:14px;margin-left:5px;
+  border-radius:50%;border:1px solid #4a5170;color:#8891b3;font-size:.66rem;font-weight:700;cursor:help;
+  position:relative;vertical-align:middle;line-height:1;}
+.rthelp:hover,.rthelp:focus{color:#c7cdea;border-color:#6a72a0;outline:none;}
+.rthelppop{display:none;position:absolute;left:0;top:calc(100% + 7px);width:290px;z-index:9;
+  background:#1a1d2b;border:1px solid #2a2e40;border-radius:10px;padding:10px 12px;box-shadow:0 12px 32px #000c;
+  text-align:left;font-weight:400;font-size:.74rem;line-height:1.55;color:#d4d8e8;cursor:default;
+  text-transform:none;letter-spacing:normal;}
+.rthelp:hover .rthelppop,.rthelp:focus .rthelppop{display:block;}
+.rthelppop code{background:rgba(42,46,64,.7);padding:0 3px;border-radius:3px;}
 .rtstep{padding:3px 2px;border-bottom:1px solid rgba(42,46,64,.5);color:#d4d8e8;}
 .rtstep.run{color:#6a7090;}
 .rtmark{display:inline-block;width:1.2em;font-weight:700;}

--- a/src/assets/js/remotes.js
+++ b/src/assets/js/remotes.js
@@ -20,6 +20,7 @@ const host = signal('');           // #rthost value
 const tr = signal('tunnel');       // transport radio
 const port = signal('');           // :direct main port (blank = auto)
 const stream = signal('');         // :direct stream port
+const rsyncPath = signal('');      // per-host rsync --rsync-path (advanced; '' = use PATH rsync)
 // Preflight stream state: { note, rows:[{name,status,ms,detail}], verdict:{ok,text}|null, err }.
 const steps = signal(null);
 let _es = null;                     // live preflight EventSource (closed on retest / modal close)
@@ -37,11 +38,31 @@ function commitXfer() {
     .then(r => r.json()).then(d => xfer.value = d).catch(() => {});
 }
 
+// ── per-host settings (rsync_path) ───────────────────────────────────────────────────────
+// Loaded when a host is picked/entered, saved before a preflight (so the dry-run uses it) and on edit.
+function loadHostSettings(h) {
+  if (!h) { rsyncPath.value = ''; return Promise.resolve(); }
+  return fetch('/api/host-settings?host=' + encodeURIComponent(h)).then(r => r.json())
+    .then(d => { rsyncPath.value = (d && d.rsync_path) || ''; }).catch(() => {});
+}
+function saveHostSettings() {
+  const h = (host.value || '').trim();
+  if (!h) return Promise.resolve();
+  return fetch('/api/host-settings', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ host: h, rsync_path: (rsyncPath.value || '').trim() }) })
+    .then(r => r.json()).then(d => { if (d && typeof d.rsync_path === 'string') rsyncPath.value = d.rsync_path; }).catch(() => {});
+}
+// Pick a host from the known list: set the input AND load its saved settings (module-scope so KnownHosts can call it).
+function pickHost(h) { host.value = h; loadHostSettings(h); }
+
 // ── preflight (SSE) ────────────────────────────────────────────────────────────────────
 // "host[,transport[,port,stream]]" — ports only for :direct, blank = auto. Remembered on success.
 function spec() { if (tr.value !== 'direct') return host.value; const p = (port.value || '').trim(), s = (stream.value || '').trim(); return p ? host.value + ',direct,' + p + (s ? ',' + s : '') : host.value + ',direct'; }
 function closeES() { if (_es) { try { _es.close(); } catch (_) {} _es = null; } }
-function runTest() {
+// Persist the per-host settings (rsync_path) FIRST — the server refreshes the live config synchronously —
+// then run the preflight so a first-time locked-down NAS provisions with the right rsync in the same click.
+function runTest() { saveHostSettings().then(_runTest); }
+function _runTest() {
   const h = (host.value || '').trim();
   if (!h) { steps.value = { note: null, rows: [], verdict: null, err: null, empty: 'Enter a host to test.' }; return; }
   const t = tr.value;
@@ -87,7 +108,7 @@ function KnownHosts() {
     ${all.map(h => {
       const isDef = h === glob, isCustom = ssh.indexOf(h) < 0, n = nreg(h);
       return html`<div class=${'rthrow' + (isDef ? ' isdef' : '')}>
-        <span class="rthname" role="button" title="use this remote" onClick=${() => host.value = h}>${isDef ? '★' : '🖧'} ${h}${isDef ? html` <em>(default)</em>` : null}${isCustom ? html` <em>(custom)</em>` : null}${n ? html` <em>(${n} region${n > 1 ? 's' : ''})</em>` : null}</span>
+        <span class="rthname" role="button" title="use this remote" onClick=${() => pickHost(h)}>${isDef ? '★' : '🖧'} ${h}${isDef ? html` <em>(default)</em>` : null}${isCustom ? html` <em>(custom)</em>` : null}${n ? html` <em>(${n} region${n > 1 ? 's' : ''})</em>` : null}</span>
         <span class="rthbtns">
           <button class="rthexp" title="regions & live workers on this host" onClick=${() => { editRegion.value = null; focusHost.value = h; }}>Regions ›</button>
           ${isDef
@@ -126,7 +147,7 @@ function Modal() {
     <button class="modalx" title="Close (Esc)" onClick=${close}>✕</button>
     <div class="msg"><strong>Remote hosts</strong><span style="display:block;margin-top:3px;font-size:.78rem;color:#7a82a4;font-weight:400">Run notebooks on another machine. A remote is any SSH host you already reach with key auth (a <code>Host</code> in ~/.ssh/config).</span></div>
     <div class="imrow"><label>Host</label><input id="rthost" spellcheck="false" autocomplete="off" placeholder="ssh_host (or user@host)"
-      value=${host.value} onInput=${e => host.value = e.target.value} onKeyDown=${e => { if (e.key === 'Enter') { e.preventDefault(); runTest(); } }}/></div>
+      value=${host.value} onInput=${e => host.value = e.target.value} onBlur=${e => loadHostSettings((e.target.value || '').trim())} onKeyDown=${e => { if (e.key === 'Enter') { e.preventDefault(); runTest(); } }}/></div>
     <div class="imrow"><label>Transport</label>
       <span class="rttr">
         <label><input type="radio" name="rttr" value="tunnel" checked=${tr.value === 'tunnel'} onChange=${() => tr.value = 'tunnel'}/> SSH tunnel</label>
@@ -135,6 +156,9 @@ function Modal() {
       <span class="rttr"><input class="rtportin" type="number" min="1024" max="65535" placeholder="main" title="remote main/REP port — blank = auto (9100+)" value=${port.value} onInput=${e => port.value = e.target.value}/>
       <input class="rtportin" type="number" min="1024" max="65535" placeholder="stream" title="remote stream/PUB port — blank = main+1" value=${stream.value} onInput=${e => stream.value = e.target.value}/>
       <span class="pddim">blank = auto</span></span></div>` : null}
+    <div class="imrow"><label>rsync path <span class="pddim">(advanced)</span><span class="rthelp" tabindex="0">?<span class="rthelppop">Absolute path to a stock <code>rsync</code> binary on this host, passed as <code>rsync --rsync-path</code>.<br/><br/>Leave blank on a normal machine. Some NAS/appliance firmware ships a modified rsync that only accepts its shared folders and rejects your home dir with <code>invalid path</code> during "Provision env" — install a normal rsync on the host (e.g. <code>~/bin/rsync</code>) and point here.<br/><br/>Saved per host.</span></span></label>
+      <input class="runonsel" spellcheck="false" autocomplete="off" placeholder="blank = use PATH rsync; e.g. /home/you/bin/rsync (locked-down NAS)"
+        value=${rsyncPath.value} onInput=${e => rsyncPath.value = e.target.value} onChange=${saveHostSettings}/></div>
     <div class="rtactions"><button class="primary" onClick=${runTest}>🩺 Test & prime</button></div>
     <div class="rtsteps"><${TestSteps}/></div>
     <${KnownHosts}/>

--- a/src/gate_kernel.jl
+++ b/src/gate_kernel.jl
@@ -642,12 +642,37 @@ _eval_timeout() = something(tryparse(Float64, get(ENV, "KAIMONSLATE_EVAL_TIMEOUT
 # default is tabulated over the helpers in remote.jl (the `_ssh_*`/`_dial_*`/… cluster); the two below
 # live here because their call sites do.
 const _REMOTE_CFG = Ref{Dict{String,Any}}(Dict{String,Any}())
-function _rcfg(key::AbstractString, env::AbstractString, default::Real)
-    v = get(_REMOTE_CFG[], key, nothing)
-    if v !== nothing
-        fv = tryparse(Float64, string(v)); fv !== nothing && return fv
+# Per-host override lookup: slate.json `remote.hosts.<host>.<key>`. Returns the raw value or nothing.
+# `host` may arrive as "user@host" (ssh target) — match the exact key first, then the bare hostname —
+# so a config keyed by plain hostname still applies to a user-qualified ssh target. Empty host ⇒ nothing
+# (no per-host layer), which collapses every accessor to its old global→env→default behaviour.
+function _rcfg_hostval(key::AbstractString, host::AbstractString)
+    isempty(host) && return nothing
+    hs = get(_REMOTE_CFG[], "hosts", nothing); hs isa AbstractDict || return nothing
+    bare = (i = findlast('@', host)) === nothing ? host : host[nextind(host, i):end]
+    for cand in (host, bare)
+        hc = get(hs, cand, nothing); hc isa AbstractDict || continue
+        v = get(hc, key, nothing); v !== nothing && return v
+    end
+    return nothing
+end
+# Precedence for every remote knob: per-host slate.json (`remote.hosts.<host>.<key>`, when `host` given)
+# → global slate.json (`remote.<key>`) → KAIMONSLATE_<ENV> → hardcoded default.
+function _rcfg(key::AbstractString, env::AbstractString, default::Real; host::AbstractString = "")
+    for v in (_rcfg_hostval(key, host), get(_REMOTE_CFG[], key, nothing))
+        if v !== nothing
+            fv = tryparse(Float64, string(v)); fv !== nothing && return fv
+        end
     end
     something(tryparse(Float64, get(ENV, env, "")), Float64(default))
+end
+# String-valued sibling of `_rcfg` (same per-host → global → env → default precedence) for non-numeric
+# knobs like a remote binary path. Empty string means "unset" at every layer.
+function _rcfg_str(key::AbstractString, env::AbstractString, default::AbstractString; host::AbstractString = "")
+    for v in (_rcfg_hostval(key, host), get(_REMOTE_CFG[], key, nothing))
+        v !== nothing && !isempty(string(v)) && return string(v)
+    end
+    e = get(ENV, env, ""); isempty(e) ? String(default) : e
 end
 # Local (127.0.0.1) worker connect deadline — worker Julia startup + KaimonGate load is slow.
 _connect_deadline_local() = _rcfg("connect_deadline_local", "KAIMONSLATE_CONNECT_DEADLINE_LOCAL", 90.0)

--- a/src/remote.jl
+++ b/src/remote.jl
@@ -149,6 +149,11 @@ const _REMOTE_KEY_PATH  = "~/.cache/kaimon/curve/server.key"
 #   blob_xfer_timeout       KAIMONSLATE_BLOB_XFER_TIMEOUT       600   whole-binding / direct-blob move gate timeout
 #   sysimage_lock_stale     KAIMONSLATE_SYSIMAGE_LOCK_STALE     1800  concurrent sysimage-build lock staleness window
 #   peer_bw_mbps            KAIMONSLATE_PEER_BW_MBPS            30    assumed rate (MB/s) for an unmeasured peer link
+#   rsync_path              KAIMONSLATE_RSYNC_PATH              ""    remote `rsync` binary (rsync --rsync-path); set on a
+#                                                                     firmware-locked NAS whose stock rsync rejects home dests.
+#                                                                     Per-host: remote.hosts.<host>.rsync_path (see _rcfg_hostval).
+# Any key above may be given PER HOST under `remote.hosts.<host>` (overrides the global `remote.<key>`); handy when one
+# machine needs a quirk (a NAS's rsync_path, a slow box's longer dial deadline) without changing the others.
 _ssh_connect_timeout()    = round(Int, _rcfg("ssh_connect_timeout",    "KAIMONSLATE_SSH_CONNECT_TIMEOUT",    15))
 _ssh_control_persist()    = round(Int, _rcfg("ssh_control_persist",    "KAIMONSLATE_SSH_CONTROL_PERSIST",    120))
 _tunnel_alive_interval()  = round(Int, _rcfg("tunnel_alive_interval",  "KAIMONSLATE_TUNNEL_ALIVE_INTERVAL",  5))
@@ -163,6 +168,14 @@ _blob_chunk_timeout_ms()  = round(Int, _rcfg("blob_chunk_timeout", "KAIMONSLATE_
 _blob_xfer_timeout()      = _rcfg("blob_xfer_timeout",      "KAIMONSLATE_BLOB_XFER_TIMEOUT",      600.0)
 _sysimage_lock_stale()    = round(Int, _rcfg("sysimage_lock_stale", "KAIMONSLATE_SYSIMAGE_LOCK_STALE", 1800))
 _peer_bw_default()        = _rcfg("peer_bw_mbps",          "KAIMONSLATE_PEER_BW_MBPS",           30.0) * 1.0e6
+# Absolute path to the `rsync` binary to invoke ON THE REMOTE (rsync's `--rsync-path`). Empty ⇒ let the
+# remote resolve `rsync` on PATH (the normal case). Needed on some appliance NAS/firmware that
+# ship a firmware-patched `rsync` which gates the server side to a whitelist of "shared folders" and so
+# rejects a home-dir dest with `invalid path` — point this at a stock rsync you dropped in, e.g.
+# `/home/<user>/bin/rsync`. Since the binary is a property of the MACHINE (many regions may share a host,
+# and the per-host preflight/provision runs before any region exists), configure it PER HOST:
+# slate.json `remote.hosts.<host>.rsync_path` (falls back to a global `remote.rsync_path` / KAIMONSLATE_RSYNC_PATH / "").
+_rsync_path(host::AbstractString = "") = _rcfg_str("rsync_path", "KAIMONSLATE_RSYNC_PATH", ""; host = host)
 
 # ── Supervised SSH tunnel (lifted from TachiRei/tunnel.jl; migrate to KaimonGate later) ──
 "An OS-assigned free local TCP port (bind :0, read it, release — small race window)."
@@ -334,7 +347,7 @@ function _ssh_julia!(host, code::AbstractString, what::AbstractString; stream::B
     write(tmp, code)
     remote = "$_REMOTE_ROOT/$(basename(tmp)).jl"
     scp_ok = try
-        run(pipeline(`scp -q $(_ssh_mux_opts()) $tmp $(string(host, ":", remote))`; stdout = devnull, stderr = devnull)); true
+        run(pipeline(`scp -O -q $(_ssh_mux_opts()) $tmp $(string(host, ":", remote))`; stdout = devnull, stderr = devnull)); true
     catch; false; end
     rm(tmp; force = true)
     scp_ok || (_rlog("FAILED: scp provisioning script → $host ($what)"); return (false, ""))
@@ -414,6 +427,7 @@ function _rsync!(host, localdir::AbstractString, remotedir::AbstractString; dele
     _ssh_ok(host, `mkdir -p $remotedir`)   # openrsync (macOS) has no --mkpath; ensure the dest exists
     args = String["-az"]
     append!(args, _rsync_ssh_opt())
+    rp = _rsync_path(host); isempty(rp) || push!(args, "--rsync-path=$rp")   # per-host stock rsync on a locked-down NAS
     delete && push!(args, "--delete")
     for e in excludes; push!(args, "--exclude", e); end
     push!(args, string(rstrip(localdir, '/'), "/"), string(host, ":", remotedir))
@@ -697,7 +711,7 @@ function _kickoff_sysimage_build!(t::RemoteTarget, projrel::AbstractString; forc
     tmp = tempname()
     write(tmp, _sysimage_build_script(projrel, sysreldir, _sysimage_minfree_gb()))
     ok = try
-        run(pipeline(`scp -q $(_ssh_mux_opts()) $tmp $(string(host, ":", remote))`; stdout = devnull, stderr = devnull)); true
+        run(pipeline(`scp -O -q $(_ssh_mux_opts()) $tmp $(string(host, ":", remote))`; stdout = devnull, stderr = devnull)); true
     catch; false; end
     rm(tmp; force = true)
     ok || (_rlog("sysimg: scp build script → $host failed (skip)"); return nothing)
@@ -1049,7 +1063,7 @@ function _launch_worker!(t::RemoteTarget, port::Int, stream_port::Int;
     tmp = tempname()
     write(tmp, script)
     try
-        run(pipeline(`scp -q $(_ssh_mux_opts()) $tmp $(string(host, ":", remote_script))`; stdout = devnull, stderr = devnull))
+        run(pipeline(`scp -O -q $(_ssh_mux_opts()) $tmp $(string(host, ":", remote_script))`; stdout = devnull, stderr = devnull))
     finally
         rm(tmp; force = true)
     end

--- a/src/server.jl
+++ b/src/server.jl
@@ -1668,6 +1668,12 @@ end
 # which sets the live ReportEngine refs AND writes slate.json.
 const _XFER_PERSIST = Ref{Any}(nothing)
 
+# Persist hook for PER-HOST remote settings (currently rsync_path). KaimonSlate installs
+# `(host, rsync_path) -> nothing` which writes slate.json `remote.hosts.<host>.rsync_path` AND refreshes
+# the live `ReportEngine._REMOTE_CFG` so the next provision/preflight uses it. Same division of labor as
+# _XFER_PERSIST/_RUNON_PERSIST (NotebookServer owns no JSON config).
+const _HOST_CFG_PERSIST = Ref{Any}(nothing)
+
 # A layer value of "local" (case-insensitive) is an EXPLICIT local pick — it forces local even when a
 # lower layer (e.g. the global default) names a host. An empty value = "no override at this layer".
 _norm_runon(s) = lowercase(strip(String(s))) == "local" ? "" : String(strip(String(s)))

--- a/src/server_complete.jl
+++ b/src/server_complete.jl
@@ -676,6 +676,33 @@ function _make_router(h::Hub)
         end
         _xfer_json()
     end)
+    # Per-HOST remote settings — currently rsync_path, the `rsync` binary to invoke ON that host (rsync's
+    # --rsync-path). Needed for a firmware-locked NAS/appliance whose stock rsync rejects a
+    # home-dir dest with `invalid path`: point this at a stock rsync you dropped in (e.g. ~/bin/rsync).
+    # GET {host} → current value. POST {host, rsync_path} persists remote.hosts.<host>.rsync_path in
+    # slate.json + refreshes the live config so the NEXT provision/preflight uses it; empty clears it.
+    _host_rsync_path(host) = begin
+        cfg = ReportEngine._REMOTE_CFG[]; hs = get(cfg, "hosts", nothing)
+        hc = hs isa AbstractDict ? get(hs, host, nothing) : nothing
+        hc isa AbstractDict ? String(get(hc, "rsync_path", "")) : ""
+    end
+    HTTP.register!(router, "GET", "/api/host-settings", req -> begin
+        host = strip(String(get(HTTP.queryparams(HTTP.URI(req.target)), "host", "")))
+        _json(Dict("host" => host, "rsync_path" => isempty(host) ? "" : _host_rsync_path(host)))
+    end)
+    HTTP.register!(router, "POST", "/api/host-settings", req -> begin
+        b = _body(req)
+        host = strip(String(get(b, "host", "")))
+        isempty(host) && return _json(Dict("ok" => false, "error" => "no host"))
+        rp = strip(String(get(b, "rsync_path", "")))
+        p = _HOST_CFG_PERSIST[]
+        p === nothing && return _json(Dict("ok" => false, "error" => "no config store (standalone hub)"))
+        try; p(host, rp)
+        catch e; @warn "slate: could not persist host settings" host = host exception = e
+            return _json(Dict("ok" => false, "error" => "persist failed"))
+        end
+        _json(Dict("ok" => true, "host" => host, "rsync_path" => _host_rsync_path(host)))
+    end)
     # Test + prime a host: the full reported dry-run (ssh, julia, provision, KaimonGate, CURVE, spawn+
     # connect+eval+teardown). Body {host, transport:"tunnel"|"direct"}. Slow on a cold host (provision).
     HTTP.register!(router, "POST", "/api/preflight", req -> begin


### PR DESCRIPTION
## Problem

Some NAS/appliance firmware ships a **patched `rsync`** that gates the server side to a whitelist of "shared folders", so a home-dir destination is rejected with `invalid path` during the "Provision env" step. The same devices often ship a **disabled sftp subsystem**, which makes the default (SFTP-protocol) `scp` fail with `Permission denied`. Both break remote-worker provisioning even when SSH and Julia themselves are fine — the preflight passes "SSH reachable" and "Julia present", then fails on "Provision env".

## Changes

- **Per-host remote config.** `_rcfg`/`_rcfg_str` gain a `host=` kwarg and a new `_rcfg_hostval`, so any remote knob resolves `remote.hosts.<host>.<key>` → global `remote.<key>` → `KAIMONSLATE_<ENV>` → default. Host matching tolerates a `user@host` ssh target (falls back to the bare hostname). Fully backward compatible. Applies uniformly to the preflight, `run_on <host>`, **and regions** (a region provisions on its `host`, so it inherits that host's config automatically).
- **`rsync_path` knob.** When set, `_rsync!` passes `--rsync-path=<path>` so provisioning uses a stock rsync you dropped in (e.g. `~/bin/rsync`) instead of the firmware-patched one. It's a machine property, hence per-host (the preflight/provision runs before any region exists).
- **`scp -O`.** The three provisioning `scp -q` calls become `scp -O -q` (legacy protocol), which bypasses `sftp-server` and works when SFTP is disabled. Harmless on normal hosts.
- **GUI.** An "rsync path (advanced)" field in the Remotes-modal host form, with a `?` help popover explaining when it's needed, saved per host via new `GET/POST /api/host-settings` (persist hook `_HOST_CFG_PERSIST`, installed at init, writes `remote.hosts.<host>.rsync_path` and refreshes the live config). Loads on host pick/blur; saved before "Test & prime" so a first-time locked-down host provisions with the right rsync in one click.

## Config shape

```json
{
  "remote": {
    "hosts": {
      "my-nas.local": { "rsync_path": "/home/you/bin/rsync" }
    }
  }
}
```

Any remote knob can be overridden the same way under `remote.hosts.<host>`.

## Verification

End-to-end on a real locked-down NAS: the preflight (provision → KaimonGate load → spawn + connect + eval round-trip) now passes. Per-host resolution, the persist/prune hook, and region-host inheritance tested live; the GUI field + help popover rendered and checked.

---

Developed with AI assistance.