### PR TITLE
feat(ui): "+" between cells to insert a cell before/after

### DIFF
--- a/src/assets/js/notebook.js
+++ b/src/assets/js/notebook.js
@@ -300,6 +300,21 @@ function Cell({ cell, selectedId, selSet, live, focusId, collapsed }) {
   return html`<div ref=${ref} id=${'cell-' + c.id} data-cid=${c.id} class=${cls}>${header}${body}</div>`;
 }
 
+// Inter-cell insert affordance: a thin hover zone in the gap between cells (and above the first / below
+// the last) that reveals a "+" to insert a cell RIGHT THERE. `afterId` = insert after that
+// cell; the top gap has no `afterId`, so it inserts BEFORE `firstId`. Left-click = code cell (in edit
+// mode); right-click = the code/markdown chooser (reuses addMenu, which inserts below `afterId`).
+function CellGap({ afterId, firstId }) {
+  const insert = (kind) => afterId
+    ? window.addCell(afterId, kind, false, true)     // between afterId and the next cell
+    : window.addCell(firstId, kind, true, true);     // top gap → before the first cell (firstId='' ⇒ append)
+  const onMenu = (e) => { e.preventDefault(); if (afterId && window.addMenu) window.addMenu(e, afterId); else insert('code'); };
+  return html`<div class="cellgap">
+    <button class="cellgap-add" onClick=${() => insert('code')} oncontextmenu=${onMenu}
+      title="insert a cell here — right-click for markdown">＋</button>
+  </div>`;
+}
+
 function Notebook({ cells, selectedId, selSet, live, focusId, cone }) {
   useEffect(() => {
     window.renderPalette && window.renderPalette();
@@ -309,8 +324,18 @@ function Notebook({ cells, selectedId, selSet, live, focusId, cone }) {
   const coneCount = cone ? cone.size : (cells || []).length;
   const banner = focusId ? html`<div class="focusbar" onClick=${() => window.slateStore.setFocus(focusId)}
       title="click or press Esc to exit focus">🔗 Dependency chain of <b>${focusId}</b> · ${coneCount} cell${coneCount === 1 ? '' : 's'} — click to exit</div>` : null;
+  const list = cells || [];
+  const firstId = list.length ? list[0].id : '';
   // Render EVERY cell always; cells outside the cone collapse (see <Cell>) instead of unmounting.
-  return html`${banner}${(cells || []).map(c => html`<${Cell} key=${c.id} cell=${c} selectedId=${selectedId} selSet=${selSet} live=${live} focusId=${focusId} collapsed=${!!(cone && !cone.has(c.id))} />`)}`;
+  // Interleave a CellGap before the first cell and after each one — EXCEPT in dep-focus, where the view
+  // is read-only-ish and gaps between collapsed cells would just be noise.
+  const rows = [];
+  if (!focusId) rows.push(html`<${CellGap} key="gap-top" afterId=${''} firstId=${firstId} />`);
+  list.forEach(c => {
+    rows.push(html`<${Cell} key=${c.id} cell=${c} selectedId=${selectedId} selSet=${selSet} live=${live} focusId=${focusId} collapsed=${!!(cone && !cone.has(c.id))} />`);
+    if (!focusId) rows.push(html`<${CellGap} key=${'gap-' + c.id} afterId=${c.id} firstId=${firstId} />`);
+  });
+  return html`${banner}${rows}`;
 }
 
 // The floating "N cells selected" pill (top-left), shown only when a multi-selection is active.

--- a/src/assets/notebook.css
+++ b/src/assets/notebook.css
@@ -161,6 +161,19 @@ body.hydrating #runstale, body.hydrating #addcellbtn { opacity:.45; pointer-even
 .cell { border:1px solid var(--border); border-left:3px solid var(--border); border-radius:8px;
         margin:14px 0; background:var(--bg2); overflow:hidden;
         scroll-margin-top:68px; }   /* jumps (DAG/TOC/nav) land the cell HEADER below the sticky topbar, with breathing room */
+/* Inter-cell insert affordance. The gap element sits in the flow between cells; its negative
+   vertical margins overlap the neighbours' 14px margins so it adds NO net height when idle. Invisible
+   until hovered, then a faint accent rule + a round "+" appear centred in the gap. */
+.cellgap { position:relative; height:20px; margin:-17px 0; display:flex; align-items:center; justify-content:center; z-index:6; }
+.cellgap::before { content:''; position:absolute; left:0; right:0; top:50%; transform:translateY(-50%);
+  height:2px; border-radius:2px; background:var(--accent); opacity:0; transition:opacity .12s; }
+.cellgap:hover::before { opacity:.28; }
+.cellgap-add { position:relative; z-index:1; display:flex; align-items:center; justify-content:center;
+  width:0; height:22px; padding:0; overflow:hidden; opacity:0; border:1px solid var(--accent); border-radius:50%;
+  background:var(--bg); color:var(--accent); font-weight:700; font-size:.95rem; line-height:1; cursor:pointer;
+  transition:opacity .12s, width .12s; }
+.cellgap:hover .cellgap-add { width:22px; opacity:1; }
+.cellgap-add:hover { background:var(--accent); color:var(--bg); }
 .cell.state-fresh   { border-left-color:var(--green); }   /* settled / up-to-date → green */
 .cell.state-stale   { border-left-color:var(--gold); }
 .cell.state-edited  { border-left-color:var(--orange); }


### PR DESCRIPTION
## What

Adds an inter-cell insert affordance: a thin hover zone in the gap between cells (and above the first / below the last) that reveals a round **+** to insert a cell right there — so you no longer have to add a cell below an existing one and then move it into place.

- **Left-click** inserts a code cell at that position (in edit mode).
- **Right-click** opens the code/markdown chooser.

## How

- `notebook.js`: a `CellGap` component interleaved in `<Notebook>` — one gap before the first cell and one after each cell (N+1 gaps for N cells). It reuses the existing `addCell(after, kind, before, edit)` path (`/api/cell-add`): a gap after a cell inserts with `before=false`; the top gap inserts before the first cell. Gaps are hidden in dep-focus (the read-oriented view).
- `notebook.css`: `.cellgap` uses negative vertical margins so it adds no height at rest and is invisible until hovered, then shows a faint accent rule + the **+** centred in the gap.

No server change — the insert API already supported before/after positioning; this is a pure front-end affordance.

## Verification

Rendered live in a notebook: 40 cells → 41 gaps (correct interleaving), each with its insert button; the gap reveals on hover and inserts at the right position.

---

Developed with AI assistance.