### PR TITLE
Wide slate_table: horizontal scroll instead of clipping columns

### DIFF
--- a/src/assets/js/core.js
+++ b/src/assets/js/core.js
@@ -394,7 +394,11 @@ function _buildShell(wrap, cols, spec, st) {
     htr.appendChild(th); return th;
   });
   thead.appendChild(htr); tbl.appendChild(thead);
-  const tbody = document.createElement('tbody'); tbl.appendChild(tbody); wrap.appendChild(tbl);
+  const tbody = document.createElement('tbody'); tbl.appendChild(tbody);
+  // Scroll wrapper: a wide table pans horizontally instead of squeezing/clipping its
+  // columns. Only the table scrolls — the filter bar and pagination stay put.
+  const scroll = document.createElement('div'); scroll.className = 'st-scroll';
+  scroll.appendChild(tbl); wrap.appendChild(scroll);
   const pag = document.createElement('div'); pag.className = 'st-pag'; wrap.appendChild(pag);
   wrap._refs = { fi, info, ths, tbody, pag };
 }

--- a/src/assets/notebook.css
+++ b/src/assets/notebook.css
@@ -491,7 +491,10 @@ body.wrap-output .output pre { white-space:pre-wrap; word-break:break-word; }
 .slatetable .st-viztoggle { background:var(--bg3); color:var(--dim); border:1px solid var(--border);
   border-radius:6px; padding:2px 8px; font-size:.74rem; cursor:pointer; font-family:inherit; }
 .slatetable .st-viztoggle:hover { color:var(--accent); }
-.slatetable .st-table { border-collapse:collapse; width:100%; font-size:.8rem; }
+/* Horizontal scroll for wide tables: the wrapper pans (matching .disp.html div.data-frame),
+   and min-width (not width) lets the table grow past the cell instead of crushing columns. */
+.slatetable .st-scroll { overflow-x:auto; max-width:100%; }
+.slatetable .st-table { border-collapse:collapse; min-width:100%; font-size:.8rem; }
 .slatetable th, .slatetable td { border:1px solid var(--border); padding:3px 9px; text-align:left;
   white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:340px; }
 .slatetable th { background:var(--bg3); color:var(--dim); cursor:pointer; user-select:none;


### PR DESCRIPTION
# Wide `slate_table`: horizontal scroll instead of clipping columns

## Problem

A table wider than its cell has no horizontal scrollbar — the data past the cell width is simply inaccessible. The interactive table is laid out as:

```css
.slatetable .st-table { border-collapse:collapse; width:100%; ... }
.slatetable th, .slatetable td { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:340px; }
```

`width:100%` pins the table to the cell width, so a many-column table squeezes its columns and the nowrap/ellipsis rules clip whatever doesn't fit, with no way to pan to it. This affects every interactive table path: `slate_table(df)`, DataFrame auto-render, inline `{{ df }}` in markdown cells, and `TableSelect`.

(The *bare*-DataFrame HTML path already handles this — `.disp.html div.data-frame` has `overflow-x:auto` — so the two table renderers currently behave inconsistently.)

## Fix

Same pattern as the bare-DataFrame path:

- `_buildShell` (core.js) wraps the `<table>` in a `.st-scroll` div — only the table pans; the filter bar and pagination stay put.
- CSS: `.st-scroll { overflow-x:auto; max-width:100%; }` and the table switches `width:100%` → `min-width:100%`, so narrow tables still fill the cell while wide ones grow to their natural width and scroll.

`wrap._refs` and the sort/filter/selection handlers are untouched — `_refreshTable` and `drawTable` work unchanged, and both table hosts (`.tables` output area and inline `.itable` placeholders) flow through `_buildShell`, so all four table paths get the fix.

## Notes

- The header's `position:sticky; top:0` now sticks within the scroll wrapper rather than the page. With paginated tables (default 25 rows) this isn't a visible change.
- Per-cell `max-width:340px` + ellipsis is kept — it guards against a single pathological cell, and with scrolling the *columns* are no longer lost.

## Testing

- Structure smoke-tested: shell builds as `.st-bar` / `.st-scroll > .st-table` / `.st-pag` with `_refs` intact.
- Manually verified in the notebook: a ~30-column DataFrame squeezed/clipped before; with the change it renders at natural width and pans horizontally, while filter/sort/pagination stay fixed. Narrow tables still fill the cell width.
