### PR TITLE
feat: per-cell toolbar action seam — slateRegisterCellAction + register_cell_action!

### DIFF
--- a/examples/extensions/StarRating/assets/star_tools.js
+++ b/examples/extensions/StarRating/assets/star_tools.js
@@ -1,0 +1,46 @@
+// StarRating's package-global front-end — the parts that aren't tied to a single `@bind`. Shipped as a
+// classic (non-module) script and injected once by Slate from the package's `__slate_frontend` hook via
+// `provide_frontend!` (no boot cell). It contributes TWO of the extension seams:
+//
+//   1. window._starRatingInsert(cellId) — the helper a per-cell TOOLBAR ACTION calls (registered in
+//      Julia via `register_cell_action!`): it scaffolds a `@bind rating Stars()` snippet into the cell's
+//      editor. Kept here (not inline in the action's onclick) so the action stays a one-liner.
+//   2. An EDITOR EXTENSION (`slateRegisterEditorExtension`): a CodeMirror keymap, on code cells only,
+//      that inserts a ★ glyph at the cursor with Ctrl-Alt-8 — the smallest useful editor add-on.
+//
+// Both guard against racing the core bundle (poll briefly for the host seam), mirroring how a cell
+// action's own injected script waits for `window.slateRegisterCellAction`.
+(function () {
+  // (1) Toolbar-action helper: append a Stars() scaffold to a cell and focus it. `window.editors[id]`
+  // is the cell's CodeMirror EditorView (see editor.js).
+  window._starRatingInsert = function (cellId) {
+    var v = (window.editors || {})[cellId];
+    if (!v) return;
+    var end = v.state.doc.length;
+    var snip = (end > 0 ? "\n" : "") + "@bind rating Stars(; max = 5)\nrating";
+    v.dispatch({ changes: { from: end, insert: snip }, selection: { anchor: end + snip.length }, scrollIntoView: true });
+    v.focus();
+  };
+
+  // (2) Editor extension: a CM6 keymap that inserts ★ at the cursor. `ctx = { markdown, cellId }`;
+  // return [] for markdown cells so it only augments code editors. `window.CM6` is the host's bundled
+  // CodeMirror surface (keymap, EditorView, …) — an extension MUST build against it, not its own copy.
+  var registerEditorExt = function () {
+    if (!window.slateRegisterEditorExtension || !window.CM6) return false;
+    window.slateRegisterEditorExtension(function (ctx) {
+      if (ctx.markdown) return [];
+      return window.CM6.keymap.of([{
+        key: "Ctrl-Alt-8",   // 8 = '*' — insert a star at the cursor
+        run: function (view) {
+          var at = view.state.selection.main.head;
+          view.dispatch({ changes: { from: at, insert: "★" }, selection: { anchor: at + 1 } });
+          return true;
+        }
+      }]);
+    });
+    return true;
+  };
+  if (!registerEditorExt()) {
+    var n = 0, t = setInterval(function () { if (registerEditorExt() || ++n > 50) clearInterval(t); }, 100);
+  }
+})();

--- a/examples/extensions/StarRating/notebooks/stars_demo.jl
+++ b/examples/extensions/StarRating/notebooks/stars_demo.jl
@@ -22,6 +22,26 @@ using StarRating
 {{rating > 0 ? "You rated it " : "Oh come on, tell us how you really feel!"}} {{rating > 0 ? join(repeat(['⭐'],rating)) : "" }} — click the stars above and this line updates reactively.
 """
 
+#%% md id=seams
+@md"""
+## …and two more extension seams — try them here
+
+StarRating is a **testbed for the whole extension SDK**, so beyond the `@bind` widget above it wires up
+two *front-end* seams from its `__slate_frontend` hook (no `__init__`, no boot cell). Both act on the
+**code cells** in this notebook — hover a code cell's header:
+
+- **Toolbar action** (`register_cell_action!`) — every code cell's header has a **★** button. Click it to
+  scaffold a `@bind rating Stars()` control right into that cell.
+- **Editor extension** (`slateRegisterEditorExtension`) — click into a code cell and press
+  **Ctrl-Alt-8** to insert a ★ at the cursor (a CodeMirror keymap, code cells only).
+
+Give them a spin in the scratch cell below.
+"""
+
+#%% code id=scratch
+# ▼ Try it here — hover this cell's header and click the ★ button to scaffold a Stars() control,
+#   or click into this cell and press Ctrl-Alt-8 to drop a ★ at the cursor.
+
 # ╔═╡ Slate.config · per-notebook settings (Settings panel)
 #   docid = f3c93d7e-ef22-4607-ae79-55ba30b6fe22
 # ╚═╡

--- a/examples/extensions/StarRating/src/StarRating.jl
+++ b/examples/extensions/StarRating/src/StarRating.jl
@@ -10,13 +10,19 @@ using StarRating
 rating                             # an Int 0…max, reactive like any @bind
 ```
 
-The whole widget is **three dispatch methods, no `__init__`**:
-- [`Stars`](@ref) + `to_widget` — a typed constructor with its own docstring/dispatch. Because its
-  `default::Int`, Slate coerces browser values to `Int` automatically (with error-fallback) — no value-
-  lifecycle code needed. (Add `register_kind!("StarRating.Stars"; domain = w -> 0:…)` only to clamp bounds.)
-- `required_assets(::Type{Stars})` — the front-end (a Preact/signals component module in `assets/stars.js`,
-  read with `@pkg_asset`). Slate loads it LAZILY the first time a `Stars` is bound, under the type-derived
-  kind — so no `__init__`, and only widgets a notebook actually uses load their JS.
+It doubles as a **testbed for the extension system**, exercising four SEB seams with no `__init__`:
+- [`Stars`](@ref) + `to_widget` — a typed `@bind` control. Because its `default::Int`, Slate coerces
+  browser values to `Int` automatically (with error-fallback). (Add `register_kind!("StarRating.Stars";
+  domain = w -> 0:…)` only to clamp bounds.)
+- `required_assets(::Type{Stars})` — the widget's front-end (a Preact/signals component in `assets/stars.js`,
+  read with `@pkg_asset`). Slate loads it LAZILY the first time a `Stars` is bound — so only widgets a
+  notebook actually uses load their JS.
+- [`InsertStarsButton`](@ref) + `to_cell_action` — a per-cell TOOLBAR ACTION: a ★ button on every code
+  cell that scaffolds a `@bind rating Stars()` snippet.
+- An EDITOR extension — a CodeMirror keymap (Ctrl-Alt-8 inserts ★ on code cells).
+
+The last two register from the package-global hook `__slate_frontend(slate_on)` (front-end shipped in
+`assets/star_tools.js`), which Slate calls once per notebook that has StarRating loaded.
 """
 module StarRating
 
@@ -46,5 +52,37 @@ SlateExtensionsBase.to_widget(s::Stars) = auto_widget(s)
 # time a `Stars` is bound (dispatch on the type), registering it under the derived kind — so there's no
 # `__init__`, and a package's widget JS loads only when a notebook actually uses that widget.
 SlateExtensionsBase.required_assets(::Type{Stars}) = @pkg_asset("assets/stars.js")
+
+# ── Extension seams beyond the @bind widget ───────────────────────────────────────────────────────
+# The `@bind` widget above needs no page-global front-end. These two do, so they register from the
+# package-global hook `__slate_frontend(slate_on)` — Slate calls it once per notebook that has
+# StarRating loaded (method-presence detection; no `__init__`, no boot cell).
+
+"""
+    InsertStarsButton(; icon, title, show, onclick)
+
+A per-cell TOOLBAR ACTION (the toolbar counterpart of a `@bind` `Widget`): a ★ button Slate adds to
+every code cell's header. Clicking it scaffolds a `@bind rating Stars()` snippet into that cell — the
+front-end helper `window._starRatingInsert` (shipped in `assets/star_tools.js`) does the insert.
+Authored the same way as a widget: a typed struct + a `to_cell_action` overload.
+"""
+Base.@kwdef struct InsertStarsButton
+    icon::String    = "★"
+    title::String   = "insert a Stars() rating control"
+    show::String    = "cell.kind === 'code'"          # code cells only
+    onclick::String = "window._starRatingInsert(cellId)"
+end
+SlateExtensionsBase.to_cell_action(b::InsertStarsButton) = auto_cell_action(b)
+
+# The package-global front-end hook. `slate_on` (for JS→Julia RPC handlers) is unused here — this demo's
+# extras are purely front-end — but the signature is fixed. Idempotent: `provide_frontend!` dedups by id
+# and `register_cell_action!` by the action's id, so Slate can re-run it every drain safely.
+function __slate_frontend(slate_on)
+    # A page-global editor extension + the toolbar-action helper (one classic script).
+    provide_frontend!(@pkg_asset("assets/star_tools.js"); id = "StarRating.tools")
+    # A ★ button on every code cell's header toolbar.
+    register_cell_action!(InsertStarsButton())
+    return nothing
+end
 
 end # module

--- a/examples/extensions/StarRating/test/runtests.jl
+++ b/examples/extensions/StarRating/test/runtests.jl
@@ -36,3 +36,33 @@ using Test
     stars = only(e for e in extension_manifest().frontend if e.id == id)
     @test stars.js == js && stars.esm == true && stars.kind == "StarRating.Stars"
 end
+
+@testset "StarRating: cell action + editor extension (__slate_frontend seam)" begin
+    empty!(SlateExtensionsBase._FRONTEND)
+
+    # The toolbar action reflects into a CellAction, on code cells, wired to the insert helper.
+    a = to_cell_action(StarRating.InsertStarsButton())
+    @test a isa CellAction
+    @test a.id == "StarRating.InsertStarsButton"               # namespaced by the package, collision-proof
+    @test a.icon == "★" && a.show == "cell.kind === 'code'"
+    @test a.onclick == "window._starRatingInsert(cellId)"
+
+    # The package-global hook registers BOTH the page front-end (editor ext + helper) and the action —
+    # no __init__, no boot cell. `slate_on` is unused by this package (its extras are pure front-end).
+    StarRating.__slate_frontend((ch, f) -> nothing)
+    byid = Dict(e.id => e for e in extension_manifest().frontend)
+
+    tools = byid["StarRating.tools"]
+    @test tools.esm == false
+    @test occursin("slateRegisterEditorExtension", tools.js)   # the editor extension
+    @test occursin("window._starRatingInsert", tools.js)       # the toolbar-action helper it calls
+
+    action = byid["cellaction:StarRating.InsertStarsButton"]
+    @test action.esm == false
+    @test occursin("window.slateRegisterCellAction", action.js)
+
+    # Idempotent — Slate re-runs the hook every drain; ids dedup, nothing stacks.
+    n = length(extension_manifest().frontend)
+    StarRating.__slate_frontend((ch, f) -> nothing)
+    @test length(extension_manifest().frontend) == n
+end

--- a/lib/SlateExtensionsBase/src/SlateExtensionsBase.jl
+++ b/lib/SlateExtensionsBase/src/SlateExtensionsBase.jl
@@ -35,12 +35,15 @@ include("controls.jl")
 include("output.jl")
 include("context.jl")
 include("frontend.jl")
+include("cell_actions.jl")
 include("render.jl")
 include("binary.jl")
 
 # Controls
 export Widget, Choice, Selection, indices, to_widget, auto_widget, kind_for
 export register_kind!, widget_kinds, coerce_bind, reconcile_bind, wrap_value, coerce_value
+# Per-cell toolbar actions
+export CellAction, to_cell_action, auto_cell_action, register_cell_action!
 # Output
 export WebPage, register_widget_js
 # Auto-registered front-end (no boot cell)

--- a/lib/SlateExtensionsBase/src/cell_actions.jl
+++ b/lib/SlateExtensionsBase/src/cell_actions.jl
@@ -1,0 +1,146 @@
+# ── Per-cell toolbar actions ──────────────────────────────────────────────────
+# A `CellAction` is the wire spec for a button an extension adds to EVERY cell's header toolbar —
+# the toolbar counterpart of a `@bind` `Widget`. The Slate front-end only ever consumes
+# `(id, icon, title, show, onclick)`; the struct never crosses a process boundary. An extension
+# authors one the same way it authors a widget — define a type and overload `to_cell_action`
+# (with `auto_cell_action` for the reflect-the-struct common case) — then hand it to
+# `register_cell_action!` from its `__slate_frontend` hook. The host seam is the JS global
+# `window.slateRegisterCellAction`, the toolbar counterpart of `window.slateRegisterEditorExtension`.
+
+"""
+    CellAction(id; icon, title="", show="", onclick)
+
+The wire spec for a per-cell toolbar button. `id` is a stable, namespaced identifier (both the
+dedup key and the DOM class — let [`auto_cell_action`](@ref) derive it from your type via
+[`kind_for`](@ref)); `icon` is the glyph shown (an emoji or HTML entity, like the built-in ▶/🗑
+buttons); `title` is the hover tooltip. `show` and `onclick` are **raw JavaScript** the extension
+owns (the same trust boundary as shipping a front-end asset):
+
+- `show` — a boolean expression over `cell` (the cell's JSON: `cell.kind`, `cell.tags`, …); `""` ⇒
+  always shown. e.g. `"cell.kind === 'code'"`.
+- `onclick` — statement(s) run on click, with `cellId`, `cell` and `event` in scope. e.g.
+  `"window.slateGiacInsert(cellId)"`.
+
+Build one directly, or return one from [`to_cell_action`](@ref) / [`auto_cell_action`](@ref).
+"""
+struct CellAction
+    id::String
+    icon::String
+    title::String
+    show::String
+    onclick::String
+end
+CellAction(id::AbstractString; icon::AbstractString, title::AbstractString = "",
+           show::AbstractString = "", onclick::AbstractString) =
+    CellAction(String(id), String(icon), String(title), String(show), String(onclick))
+
+"""
+    to_cell_action(x) -> CellAction
+
+Turn `x` into a [`CellAction`](@ref). [`register_cell_action!`](@ref) calls this, so — exactly like
+[`to_widget`](@ref) for a `@bind` control — an extension defines its own type and overloads
+`to_cell_action` for a typed, documented button (with [`auto_cell_action`](@ref) for the common
+reflect-the-struct case):
+
+```julia
+Base.@kwdef struct MathfieldButton
+    icon::String    = "∫"
+    title::String   = "insert a math field"
+    show::String    = "cell.kind === 'code'"
+    onclick::String = "window.slateGiacInsert(cellId)"
+end
+SlateExtensionsBase.to_cell_action(a::MathfieldButton) = auto_cell_action(a)
+```
+
+The identity method means an existing `CellAction` passes through unchanged.
+"""
+to_cell_action(a::CellAction) = a
+to_cell_action(x) = throw(ArgumentError(
+    "register_cell_action! expected a CellAction (or a value with a `SlateExtensionsBase.to_cell_action` " *
+    "method); got $(typeof(x))"))
+
+"""
+    auto_cell_action(x; exclude = ()) -> CellAction
+
+Build a [`CellAction`](@ref) by REFLECTING a struct's fields — the ergonomic `to_cell_action` body,
+mirroring [`auto_widget`](@ref). Fields named `icon`, `title`, `show` and `onclick` map to the
+matching wire fields (`icon` and `onclick` are required; `title` and `show` default to `""` when the
+struct has no such field); the `id` is [`kind_for`](@ref)`(typeof(x))`, so it's namespaced by your
+package and can't collide with another extension's button. `exclude` drops named fields.
+
+```julia
+SlateExtensionsBase.to_cell_action(a::MathfieldButton) = auto_cell_action(a)   # id = "GiacSlate.MathfieldButton"
+```
+"""
+function auto_cell_action(x; exclude = ())
+    T = typeof(x)
+    fns = fieldnames(T)
+    pick = (name, required) ->
+        if name in fns && name ∉ exclude
+            String(getfield(x, name))
+        elseif required
+            throw(ArgumentError("auto_cell_action($T): no `$name` field to reflect — add it, pass it in " *
+                                "`exclude` only if intentional, or build the CellAction explicitly."))
+        else
+            ""
+        end
+    return CellAction(kind_for(T); icon = pick(:icon, true), title = pick(:title, false),
+                      show = pick(:show, false), onclick = pick(:onclick, true))
+end
+
+# A JS double-quoted string literal for `s` — Base-only (no JSON dependency), and safe to embed in an
+# injected <script> (escapes `<` so a `</script>` in the text can't close the tag early).
+function _js_string(s::AbstractString)
+    io = IOBuffer()
+    print(io, '"')
+    for c in s
+        if     c == '"';       print(io, "\\\"")
+        elseif c == '\\';      print(io, "\\\\")
+        elseif c == '\n';      print(io, "\\n")
+        elseif c == '\r';      print(io, "\\r")
+        elseif c == '\t';      print(io, "\\t")
+        elseif c == '<';       print(io, "\\u003c")
+        elseif c < ' ';        print(io, "\\u", lpad(string(UInt32(c); base = 16), 4, '0'))
+        else                   print(io, c)
+        end
+    end
+    print(io, '"')
+    return String(take!(io))
+end
+
+# The registration <script> for one action: build the spec (id/icon/title are DATA, JS-escaped;
+# `show`/`onclick` are the extension's own RAW JS) and call the host seam. If the seam isn't on the
+# page yet (extension script raced ahead of the bundle), poll briefly until it is.
+function _cell_action_js(a::CellAction)
+    showexpr = isempty(strip(a.show)) ? "true" : a.show
+    return """
+    (function () {
+      var spec = {
+        id: $(_js_string(a.id)),
+        icon: $(_js_string(a.icon)),
+        title: $(_js_string(a.title)),
+        show: function (cell) { try { return !!($(showexpr)); } catch (e) { return false; } },
+        onClick: function (cellId, cell, event) { $(a.onclick); }
+      };
+      var reg = function () { if (window.slateRegisterCellAction) { window.slateRegisterCellAction(spec); return true; } return false; };
+      if (!reg()) { var n = 0, t = setInterval(function () { if (reg() || ++n > 50) clearInterval(t); }, 100); }
+    })();
+    """
+end
+
+"""
+    register_cell_action!(x)
+
+Register a per-cell toolbar button contributed by this package — call it from your module's
+`__slate_frontend(slate_on)` hook (where you also register editor extensions and RPC handlers). `x`
+is any [`to_cell_action`](@ref)-convertible value: a [`CellAction`](@ref), or your own typed button.
+Slate injects a small script that calls the front-end seam `window.slateRegisterCellAction`, so the
+button appears in every cell's action strip (gated by the action's `show`), clicking it runs the
+action's `onclick`. Idempotent — deduped by the action's `id` (a re-run replaces rather than stacks
+duplicates); live and in a static export, no boot cell.
+"""
+function register_cell_action!(x)
+    a = to_cell_action(x)
+    provide_frontend!(_cell_action_js(a); id = "cellaction:" * a.id, esm = false)
+    return nothing
+end

--- a/lib/SlateExtensionsBase/src/cell_actions.jl
+++ b/lib/SlateExtensionsBase/src/cell_actions.jl
@@ -19,7 +19,7 @@ owns (the same trust boundary as shipping a front-end asset):
 - `show` — a boolean expression over `cell` (the cell's JSON: `cell.kind`, `cell.tags`, …); `""` ⇒
   always shown. e.g. `"cell.kind === 'code'"`.
 - `onclick` — statement(s) run on click, with `cellId`, `cell` and `event` in scope. e.g.
-  `"window.slateGiacInsert(cellId)"`.
+  `"window.myExtInsert(cellId)"` (a front-end helper your extension shipped).
 
 Build one directly, or return one from [`to_cell_action`](@ref) / [`auto_cell_action`](@ref).
 """
@@ -30,9 +30,18 @@ struct CellAction
     show::String
     onclick::String
 end
+
+# A stable, namespaced identifier: it's emitted UNESCAPED-for-quotes into an inline `onclick="…('id',…)"`
+# and used as a DOM class (`cellact-<id>`), so restrict it to a leading letter + word/./- chars — no
+# quotes, spaces, or angle brackets that could break out of the attribute or the class token. `kind_for`
+# (the usual source, `Module.Type`) already satisfies this.
+const _CELL_ACTION_ID = r"^[A-Za-z][\w.\-]*$"
 CellAction(id::AbstractString; icon::AbstractString, title::AbstractString = "",
            show::AbstractString = "", onclick::AbstractString) =
-    CellAction(String(id), String(icon), String(title), String(show), String(onclick))
+    occursin(_CELL_ACTION_ID, id) ?
+        CellAction(String(id), String(icon), String(title), String(show), String(onclick)) :
+        throw(ArgumentError("CellAction id $(repr(id)) must be a namespaced identifier matching " *
+                            "$(_CELL_ACTION_ID) (e.g. \"MyPackage.MyButton\", as `kind_for` yields)."))
 
 """
     to_cell_action(x) -> CellAction
@@ -43,13 +52,13 @@ Turn `x` into a [`CellAction`](@ref). [`register_cell_action!`](@ref) calls this
 reflect-the-struct case):
 
 ```julia
-Base.@kwdef struct MathfieldButton
-    icon::String    = "∫"
-    title::String   = "insert a math field"
+Base.@kwdef struct InsertSnippetButton
+    icon::String    = "➕"
+    title::String   = "insert a snippet"
     show::String    = "cell.kind === 'code'"
-    onclick::String = "window.slateGiacInsert(cellId)"
+    onclick::String = "window.myExtInsert(cellId)"   # a helper this extension shipped
 end
-SlateExtensionsBase.to_cell_action(a::MathfieldButton) = auto_cell_action(a)
+SlateExtensionsBase.to_cell_action(a::InsertSnippetButton) = auto_cell_action(a)
 ```
 
 The identity method means an existing `CellAction` passes through unchanged.
@@ -69,7 +78,7 @@ struct has no such field); the `id` is [`kind_for`](@ref)`(typeof(x))`, so it's 
 package and can't collide with another extension's button. `exclude` drops named fields.
 
 ```julia
-SlateExtensionsBase.to_cell_action(a::MathfieldButton) = auto_cell_action(a)   # id = "GiacSlate.MathfieldButton"
+SlateExtensionsBase.to_cell_action(a::InsertSnippetButton) = auto_cell_action(a)   # id = "MyPackage.InsertSnippetButton"
 ```
 """
 function auto_cell_action(x; exclude = ())
@@ -137,7 +146,8 @@ is any [`to_cell_action`](@ref)-convertible value: a [`CellAction`](@ref), or yo
 Slate injects a small script that calls the front-end seam `window.slateRegisterCellAction`, so the
 button appears in every cell's action strip (gated by the action's `show`), clicking it runs the
 action's `onclick`. Idempotent — deduped by the action's `id` (a re-run replaces rather than stacks
-duplicates); live and in a static export, no boot cell.
+duplicates), no boot cell. A cell action is an EDITING affordance: it shows in the live editor; a
+read-only static export renders no cell toolbar, so the button simply doesn't appear there.
 """
 function register_cell_action!(x)
     a = to_cell_action(x)

--- a/lib/SlateExtensionsBase/test/runtests.jl
+++ b/lib/SlateExtensionsBase/test/runtests.jl
@@ -35,6 +35,20 @@ SlateExtensionsBase.slate_render(m::Meter) = component("Demo.Meter"; value = m.v
 struct Banner; text::String; end
 SlateExtensionsBase.slate_render(b::Banner) = html_fragment("<b>" * b.text * "</b>")
 
+# Per-cell toolbar action: a struct that reflects into a CellAction (auto_cell_action), and one that
+# omits a REQUIRED field (`onclick`) so reflection must error — mirrors the Knob/Dial widget pattern.
+Base.@kwdef struct InsertBtn
+    icon::String    = "➕"
+    title::String   = "insert a snippet"
+    show::String    = "cell.kind === 'code'"
+    onclick::String = "window.myExtInsert(cellId)"
+end
+SlateExtensionsBase.to_cell_action(a::InsertBtn) = auto_cell_action(a)
+struct NoClickBtn; icon::String; end   # no `onclick` field → auto_cell_action must throw
+# Only the REQUIRED fields — `title`/`show` are absent, so reflection must default them to "".
+Base.@kwdef struct MinBtn; icon::String = "•"; onclick::String = "f(cellId)"; end
+SlateExtensionsBase.to_cell_action(a::MinBtn) = auto_cell_action(a)
+
 @testset "SlateExtensionsBase" begin
 
     @testset "Widget construction" begin
@@ -357,6 +371,62 @@ SlateExtensionsBase.slate_render(b::Banner) = html_fragment("<b>" * b.text * "</
             slate_on("compute", a -> a + 1)
         end
         @test haskey(handlers, "compute") && handlers["compute"](1) == 2
+    end
+
+    # Per-cell toolbar actions — the toolbar counterpart of the @bind Widget path.
+    @testset "cell actions" begin
+        empty!(SlateExtensionsBase._FRONTEND)               # isolate from earlier registrations
+        # Direct construction + keyword defaults.
+        a = CellAction("Pkg.Btn"; icon = "★", onclick = "doThing(cellId)")
+        @test (a.id, a.icon, a.title, a.show, a.onclick) == ("Pkg.Btn", "★", "", "", "doThing(cellId)")
+        @test to_cell_action(a) === a                       # identity passthrough
+
+        # id must be a namespaced identifier — no quotes/spaces/brackets that break the DOM emit.
+        @test_throws ArgumentError CellAction("has space"; icon = "x", onclick = "y")
+        @test_throws ArgumentError CellAction("qu'ote"; icon = "x", onclick = "y")
+
+        # auto_cell_action reflects fields; id is kind_for(T) (module-qualified, collision-proof).
+        b = to_cell_action(InsertBtn())
+        @test b.id == "Main.InsertBtn"
+        @test b.icon == "➕" && b.show == "cell.kind === 'code'" && b.onclick == "window.myExtInsert(cellId)"
+
+        # A missing REQUIRED field errors; a non-convertible value errors too.
+        @test_throws ArgumentError auto_cell_action(NoClickBtn("x"))
+        @test_throws ArgumentError to_cell_action(42)
+
+        # register_cell_action! injects a plain (non-esm) frontend script that calls the host seam,
+        # keyed so a re-register replaces rather than stacks.
+        register_cell_action!(a)
+        man = extension_manifest()
+        entry = only(filter(e -> e.id == "cellaction:Pkg.Btn", man.frontend))
+        @test entry.esm == false
+        @test occursin("window.slateRegisterCellAction", entry.js)
+        n_before = length(man.frontend)
+        register_cell_action!(a)                            # idempotent — same id
+        @test length(extension_manifest().frontend) == n_before
+
+        # Reflection edges: a struct without `title`/`show` defaults them to ""; `exclude` drops a field.
+        m = to_cell_action(MinBtn())
+        @test (m.id, m.icon, m.title, m.show, m.onclick) == ("Main.MinBtn", "•", "", "", "f(cellId)")
+        @test auto_cell_action(InsertBtn(); exclude = (:title,)).title == ""   # excluded → back to default ""
+
+        # _js_string is the escaping that keeps injected data from breaking out of the <script> or the JS
+        # string literal — the security-relevant core. Test it directly.
+        jstr = SlateExtensionsBase._js_string
+        @test jstr("hi") == "\"hi\""
+        @test jstr("a\"b") == "\"a\\\"b\""                  # double quote escaped
+        @test jstr("a\\b") == "\"a\\\\b\""                  # backslash escaped
+        @test jstr("a\nb") == "\"a\\nb\""                   # newline → \n
+        @test occursin("\\u003c", jstr("</script>")) && !occursin("<", jstr("</script>"))  # < never literal
+        @test occursin("\\u0000", jstr("\0"))               # control char → \uXXXX
+
+        # Defense-in-depth end to end: a `<` in `icon` / a `"` in `title` is escaped in the emitted JS,
+        # so an action's DATA fields can't break the injected registration script.
+        empty!(SlateExtensionsBase._FRONTEND)
+        register_cell_action!(CellAction("Pkg.Esc"; icon = "<b>", title = "a\"b", onclick = "z()"))
+        ejs = only(extension_manifest().frontend).js
+        @test !occursin("<", ejs) && occursin("\\u003c", ejs)   # icon's `<` escaped, none left literal
+        @test !occursin("a\"b", ejs)                            # title's quote escaped
     end
 
 end

--- a/src/assets/js/editor.js
+++ b/src/assets/js/editor.js
@@ -90,6 +90,32 @@
     }
   };
 
+  // ── Cell-action registry (extension point) ───────────────────────────────────
+  // The header-toolbar counterpart of slateRegisterEditorExtension: a package can add a
+  // button to EVERY cell's action strip (the `.cellacts` cluster in cellHeaderInner) without
+  // editing core. A spec is:
+  //   { id, icon, title?, show?(cell)->bool, onClick(cellId, cell, event) }
+  // `id` dedups (re-register replaces — a reload doesn't stack duplicates); `icon` is the glyph
+  // (emoji / entity, like the built-in buttons); `show` gates per cell (default: all); `onClick`
+  // runs on click. cellHeaderInner reads the registry and emits a `<button>` per visible action,
+  // wired to _slateRunCellAction so the handler survives the innerHTML round-trip. Registering
+  // after cells have mounted asks the notebook view to re-render the headers.
+  window._slateCellActions = window._slateCellActions || [];
+  window.slateRegisterCellAction = spec => {
+    if (!spec || !spec.id || typeof spec.onClick !== 'function') return;
+    const i = window._slateCellActions.findIndex(s => s.id === spec.id);
+    if (i >= 0) window._slateCellActions[i] = spec; else window._slateCellActions.push(spec);
+    if (window._slateRefreshCells) window._slateRefreshCells();   // re-render open headers
+  };
+  // Invoked from a cell button's inline onclick (id + cell id) — looks the action and cell up and
+  // runs its handler. Kept off the button element so it survives cellHeaderInner's innerHTML render.
+  window._slateRunCellAction = (id, cellId, ev) => {
+    const s = (window._slateCellActions || []).find(x => x.id === id);
+    if (!s) return;
+    const c = ((window.__slateState || {}).cells || []).find(x => x.id === cellId) || { id: cellId };
+    try { s.onClick(cellId, c, ev); } catch (e) { console.error('slate cell action failed', e); }
+  };
+
   // Complete Julia keywords — a finished one is a token, not a completion prefix (e.g. `end`).
   const JL_KEYWORDS = new Set(['baremodule', 'begin', 'break', 'catch', 'const', 'continue', 'do',
     'else', 'elseif', 'end', 'export', 'false', 'finally', 'for', 'function', 'global', 'if', 'import',

--- a/src/assets/js/editor.js
+++ b/src/assets/js/editor.js
@@ -112,7 +112,7 @@
   window._slateRunCellAction = (id, cellId, ev) => {
     const s = (window._slateCellActions || []).find(x => x.id === id);
     if (!s) return;
-    const c = ((window.__slateState || {}).cells || []).find(x => x.id === cellId) || { id: cellId };
+    const c = ((window.__slateState || window.nbState || {}).cells || []).find(x => x.id === cellId) || { id: cellId };
     try { s.onClick(cellId, c, ev); } catch (e) { console.error('slate cell action failed', e); }
   };
 

--- a/src/assets/js/notebook.js
+++ b/src/assets/js/notebook.js
@@ -15,6 +15,21 @@ import { cells as cellsSignal, selected as selectedSignal, selectedSet as select
 const raw = s => ({ __html: s || '' });
 const _reduceMotion = !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
+// Let extension seams re-render the cell headers after they register post-hydration (e.g.
+// slateRegisterCellAction adding a toolbar button once the bundle + extension scripts have loaded).
+// Nudge the state signal — the render effect reads the `cells` COMPUTED, which dedups on Object.is, so
+// a shallow `{...nbState}` (same `.cells` array) wouldn't notify. Copy the cells array too to force a
+// fresh identity, so the top-level render re-runs cellHeaderInner for every cell (payload unchanged).
+window._slateRefreshCells = () => {
+  try {
+    const s = window.slateStore;
+    if (s && s.nbState && s.nbState.value) {
+      const st = s.nbState.value;
+      s.nbState.value = { ...st, cells: Array.isArray(st.cells) ? [...st.cells] : st.cells };
+    }
+  } catch (e) {}
+};
+
 // Dep-focus: the SET of cell ids in `id`'s dependency CHAIN — itself, its transitive precursors
 // (deps), and its transitive dependents — so focusing on a cell shows just that flow. Returns a
 // Set, or `null` when nothing is focused (→ every cell visible). All cells stay mounted either

--- a/src/assets/js/view.js
+++ b/src/assets/js/view.js
@@ -329,6 +329,12 @@ function cellHeaderInner(c) {
   const _someOn = bu.some(n => _present.has(n));
   const autoctl = bu.length
     ? `<button class="autoctl${_someOn ? ' on' : ''}" onclick="openControlPicker('${c.id}', event)" title="pick which @bind controls to surface on this cell (${bu.join(', ')})">🎛</button>` : '';
+  // Extension-contributed toolbar buttons (slateRegisterCellAction). Each visible action becomes a
+  // <button> in the action strip; the handler is looked up by id at click time (_slateRunCellAction).
+  const cellActions = (window._slateCellActions || [])
+    .filter(a => { try { return a.show ? !!a.show(c) : true; } catch (e) { return false; } })
+    .map(a => `<button class="cellact cellact-${_esc(a.id)}" onclick="_slateRunCellAction('${_esc(a.id)}','${c.id}',event)" title="${_esc(a.title || '')}">${a.icon || '•'}</button>`)
+    .join('');
   return '<span class="drag" draggable="true" title="drag to reorder">⠿</span>' +
     `<button class="collapse" onclick="toggleCollapse('${c.id}')" title="collapse / expand">${c.collapsed ? '▸' : '▾'}</button>` + run +
     `<span class="cid" title="double-click to rename">${c.id}</span>` +
@@ -362,6 +368,7 @@ function cellHeaderInner(c) {
       // last (code · web · md), so the prose toggle sits in a consistent spot.
       ['code', 'web', 'md'].filter(k => k !== c.kind).map(k =>
         `<button class="kindbtn" onclick="toggleType('${c.id}','${k}')" title="convert to ${k === 'md' ? 'markdown' : k} cell">${k === 'code' ? '{·}' : k === 'md' ? 'M↓' : '&lt;/&gt;'}</button>`).join('') +
+      cellActions +
       `<button class="del" onclick="delCell('${c.id}')" title="delete cell">🗑</button>` +
     '</span>' +
     // Run-info cluster, right-aligned and contiguous (buttons sit to its left): run time (reserved


### PR DESCRIPTION
A generic extension point for contributing a button to every cell's header toolbar, mirroring the slateRegisterEditorExtension / to_widget seams.

Host (JS):
- editor.js: window.slateRegisterCellAction registry + _slateRunCellAction dispatcher (dedup by id, retro-applies to already-mounted cells).
- view.js: cellHeaderInner renders each registered action into .cellacts, gated by the action's show(cell) predicate.
- notebook.js: _slateRefreshCells re-renders headers on late registration — copies the cells array so the `cells` computed signal's identity check fires.

SDK (SlateExtensionsBase):
- cell_actions.jl: CellAction wire spec + to_cell_action/auto_cell_action dispatch (parallel to Widget/to_widget/auto_widget, namespaced by kind_for)
  + register_cell_action! shipping the registration JS via provide_frontend!.
  
AI assisted PR