### PR TITLE
Render a value one time for each display

### DIFF
--- a/lib/SlateExtensionsBase/Project.toml
+++ b/lib/SlateExtensionsBase/Project.toml
@@ -1,6 +1,6 @@
 name = "SlateExtensionsBase"
 uuid = "bc31d39e-4442-48fa-b9ae-1bd99fed63f7"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Kahli Burke <kahli@kahliburke.com>"]
 
 [deps]

--- a/lib/SlateExtensionsBase/src/render.jl
+++ b/lib/SlateExtensionsBase/src/render.jl
@@ -82,13 +82,59 @@ SlateExtensionsBase.slate_live_render(::MyLiveThing) = true
 """
 slate_live_render(::Any) = false
 
-# `showable` == "a slate_render method returns something of this flavour". Cheap enough: capture calls it
-# once per candidate MIME while choosing the richest representation.
-Base.showable(::SlateComponentMIME, x) = (r = slate_render(x); r !== nothing && !(r isa SlateHtml))
-Base.showable(::SlateHtmlMIME, x)      = slate_render(x) isa SlateHtml
+# ── One render for each display ───────────────────────────────────────────────
+# `showable` == "a slate_render method returns something of this flavour", so it must RUN the render to
+# answer. The display capture then asks `showable` for each Slate MIME and calls `show` on the winner —
+# 3 calls of the same render for an HTML fragment, 2 for a component descriptor. A render is not always
+# cheap: a WGLMakie figure's render OPENS a Bonito session, and it must run one time only.
+#
+# The caller marks the span of ONE display with `with_render_memo`. Inside the span the first render is
+# kept and the other calls read it. Outside the span nothing is kept, and `slate_render` runs on every
+# call.
+#
+# The memo holds the value ITSELF and compares it with `===`. Do not key it on `objectid`: for a mutable
+# value `objectid` comes from the address, which the garbage collector can give to a different value
+# later. The strong reference also keeps that address occupied for as long as the memo lives.
+const _RENDER_MEMO = :slate_render_memo
 
-Base.show(io::IO, ::SlateComponentMIME, x) = _write_json(io, slate_render(x))
-Base.show(io::IO, ::SlateHtmlMIME, x)      = print(io, (slate_render(x)::SlateHtml).html)
+"""
+    with_render_memo(f)
+
+Run `f`, and make `slate_render` run ONE time for each value that `f` shows through a Slate MIME.
+
+Slate's display capture wraps the `showable` + `show` calls of one value in this. The memo is
+task-local, so parallel cells do not share it, and `finally` always clears it — a value that is shown
+again, or is changed between two displays, gets a fresh render.
+
+This is host plumbing. An extension defines `slate_render` and never calls this.
+"""
+function with_render_memo(f)
+    tls = task_local_storage()
+    prev = get(tls, _RENDER_MEMO, nothing)
+    tls[_RENDER_MEMO] = Ref{Any}(nothing)
+    try
+        return f()
+    finally
+        prev === nothing ? delete!(tls, _RENDER_MEMO) : (tls[_RENDER_MEMO] = prev)
+    end
+end
+
+# `slate_render(x)`, through the memo when a `with_render_memo` span is open.
+function _render(x)
+    memo = get(task_local_storage(), _RENDER_MEMO, nothing)
+    memo === nothing && return slate_render(x)
+    entry = memo[]
+    entry isa Tuple && entry[1] === x && return entry[2]
+    r = slate_render(x)
+    memo[] = (x, r)
+    return r
+end
+
+Base.showable(::SlateComponentMIME, x) = (r = _render(x); r !== nothing && !(r isa SlateHtml))
+Base.showable(::SlateHtmlMIME, x)      = _render(x) isa SlateHtml
+
+Base.show(io::IO, ::SlateComponentMIME, x) = _write_json(io, _render(x))
+Base.show(io::IO, ::SlateHtmlMIME, x)      = print(io, (_render(x)::SlateHtml).html)
 
 # ── Minimal JSON writer for the descriptor ────────────────────────────────────
 # SEB stays Base+stdlib only, so it can't lean on JSON.jl. The descriptor payload is small and its props

--- a/lib/SlateExtensionsBase/test/runtests.jl
+++ b/lib/SlateExtensionsBase/test/runtests.jl
@@ -34,6 +34,11 @@ struct Meter; value::Int; max::Int; end
 SlateExtensionsBase.slate_render(m::Meter) = component("Demo.Meter"; value = m.value, max = m.max)
 struct Banner; text::String; end
 SlateExtensionsBase.slate_render(b::Banner) = html_fragment("<b>" * b.text * "</b>")
+# A render that COUNTS its calls, and whose result follows a field the test changes — to check how many
+# times one display runs it, and that a changed value is not served an old render.
+mutable struct Counted; v::Int; end
+const COUNTED_CALLS = Ref(0)
+SlateExtensionsBase.slate_render(c::Counted) = (COUNTED_CALLS[] += 1; html_fragment("<i>$(c.v)</i>"))
 
 # Per-cell toolbar action: a struct that reflects into a CellAction (auto_cell_action), and one that
 # omits a REQUIRED field (`onclick`) so reflection must error — mirrors the Knob/Dial widget pattern.
@@ -399,6 +404,57 @@ SlateExtensionsBase.to_cell_action(a::MinBtn) = auto_cell_action(a)
 
         @test slate_render(42) === nothing            # a plain value → not Slate-renderable
         @test !showable(SlateComponentMIME(), 42)
+
+        # ONE display runs the render ONE time. `showable` has to RUN `slate_render` to answer, and the
+        # capture asks both Slate MIMEs before it calls `show`. A `with_render_memo` span makes those
+        # calls share one render.
+        c = Counted(1)
+        COUNTED_CALLS[] = 0
+        SlateExtensionsBase.with_render_memo() do
+            @test !showable(SlateComponentMIME(), c)
+            @test showable(SlateHtmlMIME(), c)
+            @test sprint(show, SlateHtmlMIME(), c) == "<i>1</i>"
+        end
+        @test COUNTED_CALLS[] == 1
+
+        # Outside a span the memo keeps nothing: every call renders.
+        COUNTED_CALLS[] = 0
+        showable(SlateHtmlMIME(), c)
+        showable(SlateHtmlMIME(), c)
+        @test COUNTED_CALLS[] == 2
+
+        # A span always clears the memo, so a value that CHANGED between two displays renders again and
+        # shows its new state.
+        COUNTED_CALLS[] = 0
+        SlateExtensionsBase.with_render_memo() do
+            @test sprint(show, SlateHtmlMIME(), c) == "<i>1</i>"
+        end
+        c.v = 2
+        SlateExtensionsBase.with_render_memo() do
+            @test sprint(show, SlateHtmlMIME(), c) == "<i>2</i>"
+        end
+        @test COUNTED_CALLS[] == 2
+
+        # The memo holds ONE value, so a second value in the same span gets its own render.
+        c2 = Counted(9)
+        COUNTED_CALLS[] = 0
+        SlateExtensionsBase.with_render_memo() do
+            @test sprint(show, SlateHtmlMIME(), c) == "<i>2</i>"
+            @test sprint(show, SlateHtmlMIME(), c2) == "<i>9</i>"
+        end
+        @test COUNTED_CALLS[] == 2
+
+        # A span that throws still clears the memo.
+        COUNTED_CALLS[] = 0
+        @test_throws ErrorException SlateExtensionsBase.with_render_memo() do
+            showable(SlateHtmlMIME(), c)
+            error("boom")
+        end
+        @test !haskey(task_local_storage(), SlateExtensionsBase._RENDER_MEMO)
+        SlateExtensionsBase.with_render_memo() do
+            @test sprint(show, SlateHtmlMIME(), c) == "<i>2</i>"
+        end
+        @test COUNTED_CALLS[] == 2
 
         # `component` accepts a Type (kind derived) and a props Dict/NamedTuple.
         @test component(Meter, (; a = 1))["component"] == "Main.Meter"

--- a/src/capture.jl
+++ b/src/capture.jl
@@ -139,7 +139,7 @@ end
 # all in one eval. Those methods land in a world newer than this frame, so a direct
 # `showable`/`show` would miss them and yield an empty chunk (notably on a cell's
 # first run). `invokelatest` pins the dispatch to the latest world.
-function _capture_rich!(chunks::Vector{Tuple{String,Vector{UInt8}}}, x)
+function _rich_scan!(chunks::Vector{Tuple{String,Vector{UInt8}}}, x)
     for m in _RICH_MIMES
         if Base.invokelatest(showable, m, x)
             bytes = Base.invokelatest(_mime_bytes, MIME(m), x)
@@ -151,6 +151,23 @@ function _capture_rich!(chunks::Vector{Tuple{String,Vector{UInt8}}}, x)
     end
     return false
 end
+
+# `with_render_memo` needs SlateExtensionsBase 0.9.1. Treat it as OPTIONAL, the way `_EE_OK` treats
+# ExpressionExplorer: a notebook project that declares an older SEB shadows the slate-owned infra env,
+# because it comes first on LOAD_PATH. Calling a missing function here raises `UndefVarError` inside
+# the caller's `catch`, which drops EVERY rich output to its text repr with nothing logged.
+const _RENDER_MEMO_OK = isdefined(SlateExtensionsBase, :with_render_memo)
+_RENDER_MEMO_OK ||
+    @warn "slate: SlateExtensionsBase $(pkgversion(SlateExtensionsBase)) predates `with_render_memo` — a rich render runs 2-3 times per display (upgrade to 0.9.1)"
+
+# The scan asks the two Slate MIMEs before the rest, and SEB answers `showable` for them by RUNNING
+# `slate_render`. `with_render_memo` marks this scan as one display, so those probes and the `show`
+# that follows share ONE render (see SEB `render.jl`) — an extension whose render is expensive, or
+# opens a session, does the work once. The memo covers only this call and is cleared on the way out,
+# so a value shown twice, or changed between two displays, renders again.
+_capture_rich!(chunks::Vector{Tuple{String,Vector{UInt8}}}, x) =
+    _RENDER_MEMO_OK ? SlateExtensionsBase.with_render_memo(() -> _rich_scan!(chunks, x)) :
+                      _rich_scan!(chunks, x)
 
 # Documenter `[foo](@ref)` cross-references render (via Markdown/CommonMark, e.g. a cell's `@doc name`
 # output) as `<a href="@ref">…</a>`, whose relative href resolves to `/n/@ref` → 404. Rewrite each to an

--- a/src/worker_infra/Project.toml
+++ b/src/worker_infra/Project.toml
@@ -16,7 +16,7 @@ SlateExtensionsBase = "bc31d39e-4442-48fa-b9ae-1bd99fed63f7"
 
 [compat]
 ExpressionExplorer = "1.1.4"   # keep in lockstep with the engine's pin (macroexpand.jl)
-SlateExtensionsBase = "0.9"
+SlateExtensionsBase = "0.9.1"
 
 [sources]
 SlateExtensionsBase = {path = "../../lib/SlateExtensionsBase"}


### PR DESCRIPTION
Hi @kahliburke — this follows the same Cesium work as #18, and it is a fix rather than a report.

The short version: an extension author should be able to define `slate_render` and stop thinking
about it. Right now that only works if the render is pure and cheap.

`SlateExtensionsBase` answers `showable` by calling `slate_render` and discarding the result
(`lib/SlateExtensionsBase/src/render.jl`):

```julia
Base.showable(::SlateComponentMIME, x) = (r = slate_render(x); r !== nothing && !(r isa SlateHtml))
Base.showable(::SlateHtmlMIME, x)      = slate_render(x) isa SlateHtml
Base.show(io::IO, ::SlateComponentMIME, x) = _write_json(io, slate_render(x))
```

`_capture_rich!` (`src/capture.jl`) asks each rich MIME in turn and shows the first that answers
yes, so one display runs the render more than one time. Measured with a render that increments a
counter:

| The render returns | Before | After |
|---|---|---|
| a component descriptor | 2 | 1 |
| an HTML fragment | 3 | 1 |

Same counts on the `display()` path and on the return-value path.

## Why it matters

The SDK's contract is one method. An extension "defines ONE dispatch method, `slate_render(x)`" and
SEB "owns the `show`/`showable` plumbing" — `render.jl` says exactly that at the top. The contract
holds while the render is pure and cheap. The moment it costs something, or has a side effect, it
quietly stops holding, and the way an author finds out is by shipping something that runs its side
effect two or three times per display.

Recovering from that is not a small step. The author has to override `Base.showable` for BOTH Slate
MIMEs, override `Base.show` as well, and then work out why the obvious signature is ambiguous
against the display methods their plotting or widget package already defines. At that point the SDK
is no longer "define one method" — it is "reimplement the plumbing, correctly, on concrete types".

This repo is the existence proof, twice. `BonitoSlate/src/figure.jl` does it for three concrete
Makie types, with fifteen lines of comment about method ambiguity and about overwriting a method
another module owns, and `app.jl:171` repeats the pattern for a Bonito app. The comment names the
reason plainly:

> We keep `showable` a cheap backend check (NOT `slate_render(fig) isa SlateHtml`) so a WGLMakie
> figure — whose render OPENS a Bonito session — renders exactly ONCE (in `show`), not again on
> every `showable` probe.

Every extension whose render does real work has to rediscover that and re-derive the workaround.
With one render per display it stops being necessary: an author writes `slate_render`, and whatever
the render does — allocate, open a session, talk to a device — happens once.

The saved work is a secondary benefit, and small when the render is cheap: a trivial
`component(...)` descriptor measures roughly 15% faster per display, while the memo costs a couple
of hundred nanoseconds on a value that has no Slate render at all. The reason to do this is the
contract, not the microseconds.

## The fix

`SlateExtensionsBase.with_render_memo(f)` marks the span of one display. Inside the span the first
render is kept and the other calls read it. Outside the span nothing is kept and `slate_render` runs
on every call, as today. `_capture_rich!` opens the span around its MIME scan.

Two notes on the design:

- The memo holds the value **itself** and compares with `===`, not `objectid`. For a mutable value
  `objectid` comes from the address, and the garbage collector can hand that address to a different
  value later. The strong reference also keeps the address occupied while the memo lives.
- The span is opened by the caller and cleared in a `finally`, rather than being an ambient
  task-local cache with a generation counter. Nothing inside SEB can see a display begin or end, so
  an ambient entry has no reliable retirement point. Concretely: a plain value renders `nothing`, no
  Slate `show` ever runs, and the entry would survive — so a later cell defining `slate_render` for
  that type would be served the stale `nothing`. That is the same world-age case the `invokelatest`
  in `_capture_rich!` already guards.

The API does not change, and no extension calls `with_render_memo` — it is host plumbing, so it is
not exported.

## `with_render_memo` is treated as optional

`with_render_memo` arrives in SEB 0.9.1, but `capture.jl` does not require it. It is guarded the way
`_EE_OK` guards ExpressionExplorer, because a compat bound cannot protect this call:

A notebook project that declares `SlateExtensionsBase` shadows the slate-owned infra env — the infra
env sits AFTER the notebook project on `LOAD_PATH` (`src/gate_kernel.jl:516`), which is what
`worker_infra/Project.toml` intends ("the notebook's own copies always win"). So the worker can run
current `capture.jl` against an older SEB no matter what KaimonSlate's own compat says. That is not
hypothetical — an extension author's repo declares SEB, e.g. `BonitoSlate/Project.toml`.

Unguarded, the missing function raises `UndefVarError` inside the bare `catch` around
`_capture_rich!` (`src/capture.jl:691`), and **every rich output silently drops to its `text/plain`
repr**. I hit exactly that while testing: in a notebook whose project pinned SEB `=0.9.0`, a value
with a `slate_render` method came back as `Main.NB.Widget2()`, no error, nothing logged.

With the guard that notebook renders normally and only loses the memo, and the worker logs one
warning at boot. So **the KaimonSlate compat bound stays at `0.9`** — an older SEB remains
supported. Only `src/worker_infra/Project.toml` pins `0.9.1`, and that env path-devs SEB out of the
package's own `lib/`, so it gets the new SDK from the installed tree rather than the registry.

Net effect on release order: none. Registering SEB 0.9.1 is worthwhile so a standalone SEB user gets
the fix, but nothing here waits on it, and a fresh clone resolves against the registry as before.

## Verified

In a live notebook whose worker loads this SEB from source (`pathof` checked):

- component descriptor and HTML fragment: 1 render for each display, on both the `display()` path
  and the return-value path.
- a value **changed between two displays** renders again and shows its new state — the render saw
  `[1, 2]`, not `[1]`.
- a value displayed **before** its `slate_render` method exists renders as `text/plain`, then as
  `html+html` once a later cell defines the method. No stale `nothing`.
- live re-render (`rerender_live_outputs` / `_LIVE_OUTPUTS`): the retained cell re-renders, emits the
  right MIME, and runs the render 1 time, down from 3.
- static export (`GET /api/{id}/export.html`): the component descriptor and every fragment survive,
  including the two distinct renders of the changed value.
- **older SEB**: a notebook project pinning `=0.9.0` renders `html+html` normally and logs the
  warning, instead of silently degrading to text.
- BonitoSlate: with a generic `slate_render(::Makie.Figure)` planted as a tripwire, a WGLMakie figure
  still reports `showable(component)=false`, `showable(html)=true`, and calls the generic render 0
  times, inside and outside a span — the concrete overrides still win, no ambiguity `MethodError`.
  The memo never holds a figure. CairoMakie still falls through to `image/png`.
  `SlateExtensionsBaseMakieExt` precompiles against the changed methods.
- `SlateExtensionsBase` test suite: 188 pass, including 15 new assertions.
- `KaimonSlate` precompiles; a fresh resolve against the registry works, warning and all.

## Versions

KaimonSlate 1.0.1 (`main` @ 341f550b), SlateExtensionsBase 0.9.0 → 0.9.1, Julia 1.12.6.
