### PR TITLE
Namespace the tmp log directory per user

### DIFF
--- a/src/KaimonSlate.jl
+++ b/src/KaimonSlate.jl
@@ -899,7 +899,7 @@ function create_tools(GateTool::Type)
             if !(k.target isa ReportEngine.RemoteTarget)
                 ReportEngine.shutdown!(k)
                 for ext in ("log", "json", "state", "stats")
-                    try; rm(joinpath(tempdir(), "kaimonslate", "worker-$(k.port).$ext"); force = true); catch; end
+                    try; rm(joinpath(ReportEngine._slate_tmpdir(), "worker-$(k.port).$ext"); force = true); catch; end
                 end
                 return "✅ reaped worker-$(k.port) for '$(nb.id)' (process killed, files removed). " *
                        "It has no worker until the next run — action=restart brings one straight back."

--- a/src/gate_kernel.jl
+++ b/src/gate_kernel.jl
@@ -703,6 +703,10 @@ function _worker_script(port::Int, stream_port::Int, parent::AbstractString = ""
     """
 end
 
+# tempdir() is shared by every user on the machine, so a fixed "kaimonslate" name is owned by
+# whoever creates it first and unwritable (0700) for everyone else. Namespace it per user.
+_slate_tmpdir() = joinpath(tempdir(), "kaimonslate-" * get(ENV, "USER", "user"))
+
 function _spawn_worker!(k::GateKernel)
     k.ns_gen += 1   # a fresh LOCAL process ⇒ blank namespace (mirrors spawn_and_connect_remote!): the
                     # ns_gen-keyed re-establish re-primes it — main-kernel @bind registrations here, and
@@ -711,7 +715,7 @@ function _spawn_worker!(k::GateKernel)
     port, stream_port = _next_ports()
     k.port = port; k.stream_port = stream_port
     _clear_stale_pin!(port)
-    logdir = joinpath(tempdir(), "kaimonslate"); mkpath(logdir)
+    logdir = _slate_tmpdir(); mkpath(logdir)
     # Worker stdout/stderr can carry notebook data — keep the shared tmp dir private (0700) so
     # other local users can't read the logs; the file itself is locked to 0600 when opened below.
     Sys.isunix() && (try; chmod(logdir, 0o700); catch; end)
@@ -761,14 +765,19 @@ function _spawn_worker!(k::GateKernel)
     close(out.in)
     online = k.online   # captured once — a respawn gets a fresh GateKernel, so this can't go stale mid-pump
     Threads.@spawn begin
-        io = open(k.logpath, "w")
-        Sys.isunix() && (try; chmod(k.logpath, 0o600); catch; end)
+        io = nothing
+        try
+            io = open(k.logpath, "w")
+            Sys.isunix() && (try; chmod(k.logpath, 0o600); catch; end)
+        catch e
+            @warn "SlateWorker log file could not be opened — worker output is being discarded" log = k.logpath exception = e
+        end
         try
             # Line-by-line (not chunked `readavailable`) so a slow first-run precompile can narrate
             # itself live via `online`, mirroring the remote path's `_run_streamed`. Net effect on the
             # log file is the same content, just written one newline-terminated line at a time.
             for line in eachline(out)
-                println(io, line); flush(io)
+                io === nothing || (println(io, line); flush(io))
                 if online !== nothing
                     s = strip(line)
                     isempty(s) || (try; online(String(s)); catch; end)
@@ -776,7 +785,7 @@ function _spawn_worker!(k::GateKernel)
             end
         catch
         finally
-            close(io)
+            io === nothing || close(io)
         end
         # EOF on the pipe means the PROCESS is gone. That is the one death signal which is exact and
         # immediate — the liveness probe can only ever infer death from silence, and silence is also

--- a/src/server.jl
+++ b/src/server.jl
@@ -3360,7 +3360,7 @@ function serve_notebook(path::AbstractString; host = "127.0.0.1", port = 8765, q
                         inactive::Bool = false, app::Bool = false,
                         appdefaults::AbstractDict = Dict{String,Any}())
     # Swap the logger BEFORE anything spawns so worker-spawn infos land in the file.
-    logpath = joinpath(tempdir(), "kaimonslate", "hub-$port.log")
+    logpath = joinpath(ReportEngine._slate_tmpdir(), "hub-$port.log")
     logio = nothing
     prevlogger = nothing
     if quiet

--- a/src/server_history.jl
+++ b/src/server_history.jl
@@ -524,7 +524,7 @@ const _DBLOB_DIR = Ref{String}("")
 function _dblob_dir()
     if _DBLOB_DIR[] == ""
         d = joinpath(get(ENV, "XDG_CACHE_HOME", joinpath(get(ENV, "HOME", tempdir()), ".cache")), "kaimonslate", "blobs")
-        try; mkpath(d); catch; d = joinpath(tempdir(), "kaimonslate-blobs"); mkpath(d); end
+        try; mkpath(d); catch; d = joinpath(tempdir(), "kaimonslate-" * get(ENV, "USER", "user") * "-blobs"); mkpath(d); end
         _DBLOB_DIR[] = d
     end
     return _DBLOB_DIR[]

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -176,7 +176,7 @@ function _memo_dir()
                !isempty(home)  ? joinpath(abspath(expanduser(home)), "cache") :
                joinpath(get(ENV, "XDG_CACHE_HOME", joinpath(get(ENV, "HOME", tempdir()), ".cache")), "kaimonslate")
         d = joinpath(base, "memo")
-        try; mkpath(d); catch; d = joinpath(tempdir(), "kaimonslate-memo"); mkpath(d); end
+        try; mkpath(d); catch; d = joinpath(tempdir(), "kaimonslate-" * get(ENV, "USER", "user") * "-memo"); mkpath(d); end
         _MEMO_DIR[] = d
     end
     return _MEMO_DIR[]


### PR DESCRIPTION
## Problem

`tempdir()` is shared by every user on the machine, so the fixed `$TMPDIR/kaimonslate` directory belongs to whichever user creates it first.
Because it is chmod'd `0700`, every *other* user on that box then gets `EACCES` on both `mkpath` and `open` — no worker logs, no hub log, for the entire lifetime of the machine.

Observed on a shared build host: `/tmp/kaimonslate` was `drwx------` owned by another user, and a second user running KaimonSlate got no logs at all.

## The pipe-drain bug this exposed

In `_spawn_worker!`, the log pump opened its file *before* the `try`:

```julia
io = open(k.logpath, "w")   # throws here …
try
    for line in eachline(out)   # … so this never runs
```

A failed open therefore killed the pump task before it ever read the worker's stdout pipe. The worker then ran until it filled the 64 KB pipe buffer and blocked there permanently — the notebook simply hung, with no error pointing at the log directory.

So the permission bug did not merely lose logs; it wedged the worker.

## Changes
- ReportEngine._slate_tmpdir() — one helper returning joinpath(tempdir(), "kaimonslate-" * get(ENV, "USER", "user")). The three
  call sites that must agree on the directory name go through it: worker spawn (gate_kernel.jl), hub log (server.jl), worker reap (KaimonSlate.jl).
- The log-pump open moves inside the try. On failure it warns with the path and the exception, and the pipe is still drained to EOF with output discarded. The pipe is now read to EOF on every path.
- The two independent shared-tmp fallbacks are namespaced the same way: _dblob_dir() → kaimonslate-$USER-blobs, _memo_dir() → kaimonslate-$USER-memo.

mkpath and the 0700 directory / 0600 file permissions are unchanged.

Paths under ~/.cache/kaimonslate and $XDG_* are deliberately untouched, they are already per-home and were never the shared-directory problem.

## Testing
- Full suite: 3708 tests pass, 0 failures, 0 errors.
- Verified live: after restarting the server and extension and opening a notebook, /tmp/kaimonslate-$USER/ appears as drwx------ owned by the running user and contains hub-<port>.log and worker-<port>.log, all files 0600.