### PR TITLE
Add support for multiple cursors

### DIFF
--- a/docs/src/notebook-basics.md
+++ b/docs/src/notebook-basics.md
@@ -57,6 +57,13 @@ In edit mode:
 | `⌘⇧⏎` / `Ctrl⇧⏎` | run and open a fresh cell below |
 | `⌘⇧-` / `Ctrl⇧-` | split the cell at the cursor |
 | `⇥` | completion (Julia REPL completions + cell-local bindings) |
+| `⌘⌥↑` / `⌘⌥↓` | add a caret on the line above / below |
+| `⌥`-click | add a caret at the click |
+| `⌘D` / `CtrlD` | select the word under the caret, then each next occurrence |
+
+Extra carets type together.
+`Esc` drops back to a single caret, or clears a selection, and a second `Esc` returns to command mode.
+Under the vim keymap `Esc` keeps its vim meaning: it leaves insert or visual mode, and from normal mode it returns to command mode without collapsing the carets.
 
 Notebook-wide:
 

--- a/src/assets/js/editor.js
+++ b/src/assets/js/editor.js
@@ -5,7 +5,7 @@
 (function () {
   const CM = window.CM6;
   if (!CM) { console.error('CM6 bundle missing'); return; }
-  const { EditorView, EditorState, EditorSelection, Compartment, StateField, StateEffect, Decoration, Transaction,
+  const { EditorView, EditorState, Compartment, StateField, StateEffect, Decoration, Transaction,
           ViewPlugin, WidgetType, Prec,
           vimMode, vimApi, vimGetCM, emacsMode,
           keymap, defaultKeymap, history, historyKeymap, undoDepth, redoDepth, indentWithTab, toggleComment,
@@ -16,7 +16,7 @@
 
           autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap,
           completionStatus, startCompletion, acceptCompletion, snippet,
-          cmSearch, cmView } = CM;
+          cmSearch, cmView, cmCommands } = CM;
 
   // ── Every live editor view ──────────────────────────────────────────────────────
   // The audience for a settings change: theme, wrap, keymap, completion delay and the extension
@@ -142,6 +142,11 @@
         const buf = vs.inputState && vs.inputState.keyBuffer;
         if (buf && buf.length) { try { vimApi.handleKey(cm, '<Esc>', 'user'); } catch (_) {} return true; }
       }
+      // defaultKeymap's own Escape binding, which this ladder pre-empts: collapse a selection or
+      // extra carets. It returns false on a bare caret, so a plain Escape still leaves the cell.
+      // Not under vim, where normal-mode <Esc> is a no-op pressed to assert the mode; `vs` is null
+      // under emacs, which binds no Escape.
+      if (!vs && cmCommands.simplifySelection(view)) return true;
       view.contentDOM.blur();
       return true;
     },
@@ -199,6 +204,16 @@
   };
 
   window.editors = window.editors || {};
+
+  // ── Multiple cursors ──────────────────────────────────────────────────────────
+  // The gestures are documented in notebook-basics.md. CodeMirror supplies the rest once multiple
+  // ranges are allowed: defaultKeymap already binds ⌘⌥↑/↓ to addCursorAbove/Below and Escape to
+  // simplifySelection, and `drawSelection()` (on every editor) draws the extra carets.
+  const _multiCursor = [
+    EditorState.allowMultipleSelections.of(true),   // without it CM6 discards all but one range
+    // ⌘ is go-to-definition and ⌃ is the macOS context menu, so require ⌥ alone.
+    EditorView.clickAddsSelectionRange.of(e => e.altKey && !e.metaKey && !e.ctrlKey),
+  ];
 
   // ── Editor-extension registry (extension point) ──────────────────────────────
   // A package can teach EVERY cell editor a new behaviour (e.g. render giac"…" as an
@@ -832,6 +847,8 @@
         history(), drawSelection(), bracketMatching(), closeBrackets(), indentOnInput(),
         indentUnit.of(_indent), EditorState.tabSize.of(webLang ? 2 : 4), errField, originField, flashField,
         wrapComp.of(_wrapExt(!!opts.markdown)),
+        ..._multiCursor,
+        ...(cmSearch ? [cmSearch.highlightSelectionMatches()] : []),   // marks the selection's other occurrences
         ...lang,
         // Web panes: inline syntax-error diagnostics (a red underline) as you type, so a typo like
         // `for x of …` is caught at author time instead of a cryptic runtime console error. No lint
@@ -863,6 +880,10 @@
           // inside the activate-on-typing delay and made you press it twice.
           ...completionKeymap,                  // popup nav/close, once there IS a popup
           ...cellKeys,
+          // ⌘⌥↑/↓ come from defaultKeymap. ⌘D does not: selectNextOccurrence is in searchKeymap,
+          // which only the Files-tab editor gets. `keymapModeComp` precedes this keymap, so on
+          // Linux, where Mod is Ctrl, vim and emacs keep Ctrl-D.
+          ...(cmSearch ? [{ key: 'Mod-d', run: cmSearch.selectNextOccurrence, preventDefault: true }] : []),
           // ⌘⇧K = help (app shortcut). Bind it here so CM6's defaultKeymap `deleteLine` doesn't eat it.
           { key: 'Mod-Shift-k', run: () => { window.__docsHotkey = Date.now(); window.openDocsAtCursor && window.openDocsAtCursor(); return true; } },
           // ⌘⇧←/→ = back/forward through selected-cell nav history, IN the editor too — so after a
@@ -940,6 +961,11 @@
           '.cm-cursor': { borderLeftColor: 'var(--text)' },
           '&.cm-focused': { outline: 'none' },
           '.cm-line': { padding: '0 4px' },
+          // highlightSelectionMatches ships a fixed #99ff7780 green that ignores the editor theme.
+          // Neutral tint instead, overridable per theme through the two variables.
+          '.cm-selectionMatch': { backgroundColor: 'var(--selmatch-bg, rgba(127,127,127,.20))',
+                                  outline: '1px solid var(--selmatch-line, rgba(127,127,127,.38))',
+                                  borderRadius: '2px' },
         }, { dark: true }),
       ],
     });

--- a/test/js/vim_escape.mjs
+++ b/test/js/vim_escape.mjs
@@ -39,11 +39,17 @@ const vimApi = {
   exitVisualMode: () => { acted = 'visual'; },
   handleKey: (_cm, key) => { acted = 'key:' + key; },
 };
-const keydown = new Function('completionStatus', '_vimCM', '_vimState', 'vimApi', 'return function keydown(e, view) ' + body.slice(body.indexOf('{')) + ';')(
+// `cmCommands.simplifySelection` stands in for the selection rung. The real one collapses extra
+// carets or a non-empty selection and returns false on a bare caret, which is what lets a plain
+// Escape fall through to leaving the cell; `cursors > 1` models "there was something to collapse".
+let cursors = 1, collapsed = 0;
+const cmCommands = { simplifySelection: () => (cursors > 1 ? (collapsed++, cursors = 1, true) : false) };
+const keydown = new Function('completionStatus', '_vimCM', '_vimState', 'vimApi', 'cmCommands', 'return function keydown(e, view) ' + body.slice(body.indexOf('{')) + ';')(
   () => completion,
   () => (vimState ? { state: { vim: vimState } } : null),
   () => vimState,
   vimApi,
+  cmCommands,
 );
 const view = { state: {}, contentDOM: { blur: () => { blurred++; } } };
 const esc = (over = {}) => Object.assign({ key: 'Escape', ctrlKey: false, metaKey: false, altKey: false }, over);
@@ -53,11 +59,11 @@ function check(what, got, want) {
   if (got !== want) { console.error(`vim_escape: ${what} — got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`); bad++; }
 }
 // One press under a given completion/vim state → {handled, blurred, acted}.
-function press(ev, comp, vs) {
-  completion = comp; vimState = vs; acted = null;
-  const before = blurred;
+function press(ev, comp, vs, carets = 1) {
+  completion = comp; vimState = vs; acted = null; cursors = carets;
+  const before = blurred, wasCollapsed = collapsed;
   const handled = keydown(ev, view);
-  return { handled, blurred: blurred > before, acted };
+  return { handled, blurred: blurred > before, acted, collapsed: collapsed > wasCollapsed };
 }
 
 const OFF = null, INSERT = { insertMode: true, visualMode: false };
@@ -89,7 +95,27 @@ check('visual exits even while a completion is pending', press(esc(), 'pending',
 check('a pending operator is cancelled', press(esc(), 'none', PENDING_OP).acted, 'key:<Esc>');
 check('a pending operator does not leave the cell', press(esc(), 'none', PENDING_OP).blurred, false);
 
-// Rung 4 — nothing inner is live, so Escape means what it has always meant.
+// Rung 4: a selection or an extra caret is inner to the cell itself, so Escape simplifies before it
+// will give up the cell. This is defaultKeymap's Escape command, which the ladder pre-empts.
+check('an extra caret collapses', press(esc(), 'none', OFF, 2).collapsed, true);
+check('collapsing does not leave the cell', press(esc(), 'none', OFF, 2).blurred, false);
+check('collapsing reports handled', press(esc(), 'none', OFF, 2).handled, true);
+check('a bare caret is not a rung', press(esc(), 'none', OFF, 1).collapsed, false);
+// The popup outranks the carets. Without this case the rung's position below rung 1 is unpinned,
+// and an Escape meant to dismiss a completion would silently drop the extra carets instead.
+check('an active completion outranks the carets', press(esc(), 'active', OFF, 2).collapsed, false);
+check('an active completion is still handed on with carets present', press(esc(), 'active', OFF, 2).handled, false);
+// Under vim this rung is skipped entirely. Normal-mode `<Esc>` is a deliberate no-op a vim user
+// presses to assert the mode, so it keeps the meaning main gives it and leaves the cell, extra
+// carets and all. This is the whole of vim's exposure to multiple cursors, and it is nil.
+check('vim normal mode does not collapse', press(esc(), 'none', NORMAL, 2).collapsed, false);
+check('vim normal mode still leaves the cell with carets', press(esc(), 'none', NORMAL, 2).blurred, true);
+check('vim insert exits insert rather than collapsing', press(esc(), 'none', INSERT, 2).collapsed, false);
+check('vim insert still does not leave the cell', press(esc(), 'none', INSERT, 2).blurred, false);
+// Emacs is modeless and binds no Escape, so `_vimState` is null for it and it collapses like the
+// default keymap; the OFF cases above are exactly that path.
+
+// Rung 5: nothing inner is live, so Escape means what it has always meant.
 check('normal mode leaves the cell', press(esc(), 'none', NORMAL).blurred, true);
 check('normal mode reports handled', press(esc(), 'none', NORMAL).handled, true);
 check('normal mode does not touch vim', press(esc(), 'none', NORMAL).acted, null);


### PR DESCRIPTION
This PR adds support for multiple cursors by activating relevant CodeMirror 6 features. It also adds support for Cmd+D, a keybinding that selects the current and next instance of the word at the current cursor.

Added a test to verify behavior.

Tested on macOS only.
