### PR TITLE
Test on Julia 1.13 as well as 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.12'   # the `slate` app + engine target Julia 1.12
+          - '1.12'   # the `slate` app + engine target Julia 1.12, and compat floors there
+          - '1.13'   # current release: catch what the next Julia breaks before a user does
         os:
           - ubuntu-latest
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -52,7 +52,10 @@ Mmap = "1.11.0"
 OteraEngine = "1.1.3"
 Pkg = "1.11.0"
 REPL = "1.11.0"
-ReTest = "0.3"
+# ReTest 0.3.4 claims julia 1.10+ but does not precompile on 1.13 — it imports
+# Test.push_testset/pop_testset, which 1.13 removed. 0.4 is the 1.13 release and is
+# itself gated to julia >= 1.13, so listing both lets each Julia take the one that works.
+ReTest = "0.3.4, 0.4"
 SHA = "0.7, 1"
 Serialization = "1.11.0"
 SlateExtensionsBase = "0.10.4"

--- a/src/capture.jl
+++ b/src/capture.jl
@@ -470,7 +470,12 @@ function _asset_base(name::AbstractString)
     safe == stem && return safe
     return string(safe, "-", string(hash(stem) % UInt16; base = 36))
 end
-_asset_hash(x) = string(hash(x) % UInt32; base = 16, pad = 8)   # short id → cache-bust + dedup
+# Short id → cache-bust + dedup. `slate_fingerprint`, not `hash`: this ends up in the FILENAME of an
+# exported asset, so it has to mean the same thing everywhere. `hash` is not stable across Julia
+# versions (1.12 and 1.13 disagree on the same bytes), which would rename every asset in a published
+# site on a Julia upgrade and give two collaborators different names for identical content — exactly
+# the dedup this is for. It also leaks Dict iteration order, which the JSON branch below passes in.
+_asset_hash(x) = slate_fingerprint(x)[1:8]
 
 function _asset_push!(rec)
     rec = merge(rec, (; created = time()))   # stamp when the cell produced it (survives memo restore)

--- a/test/test_complete.jl
+++ b/test/test_complete.jl
@@ -116,17 +116,29 @@ end
     items = RE.slate_completions(m, code, ncodeunits(code)).items
     texts = first.(items)
 
+    # Julia 1.13 narrowed REPLCompletions: completing `M.` offers only what M itself binds, where
+    # 1.12 also enumerated everything M reaches through `using Base` (1120 items for a bare module
+    # against 1). The demotion below exists to keep a module's own names ahead of that inherited
+    # crowd, so it has work to do only on the versions that still produce a crowd — 1.13 does
+    # upstream what it was compensating for. Both orderings are correct; assert the intent, and
+    # check the demotion itself only where there is something to demote.
+    inherited = "sin" in texts
+
     @testset "nothing is removed" begin
+        @test "shown" in texts && "hidden" in texts
         # Base is reachable as `_ApiFixture.sin` and stays offered, just not in the way.
-        @test "sin" in texts
-        @test length(items) > 100
+        if inherited
+            @test length(items) > 100
+        end
     end
 
     @testset "its own bindings come first" begin
         lead = texts[1:min(8, end)]
         @test "shown" in lead && "hidden" in lead     # exported and unexported alike: both are ITS names
-        @test findfirst(==("shown"), texts) < findfirst(==("sin"), texts)
-        @test findfirst(==("hidden"), texts) < findfirst(==("sin"), texts)
+        if inherited
+            @test findfirst(==("shown"), texts) < findfirst(==("sin"), texts)
+            @test findfirst(==("hidden"), texts) < findfirst(==("sin"), texts)
+        end
     end
 
     @testset "a bare identifier is untouched" begin

--- a/test/test_export.jl
+++ b/test/test_export.jl
@@ -562,7 +562,10 @@ end
     nref = _RE._save_asset("nt", (msg = "hi", n = 42))            # NamedTuple → JSON
     harvested = _RE._harvest_assets(task_local_storage(:slate_assets))
     delete!(task_local_storage(), :slate_assets)
-    @test "$(ref)" == "data/airports-1d6b6d68.json"               # AssetRef interpolates to its path
+    @test "$(ref)" == "data/airports-d3198338.json"               # AssetRef interpolates to its path
+    # Not just "a hash": the SAME hash on every Julia. This literal is the guard on that — it is
+    # what a published site's asset filenames are, so a version-dependent digest would rename
+    # every one of them on an upgrade.
     @test ref.mime == "application/json"
     @test length(harvested) == 5                                  # dup collapsed (6 saved → 5)
     @test any(a -> endswith(a.path, ".bin"), harvested)           # raw bytes → .bin


### PR DESCRIPTION
1.13.0 is out and `julia = "1.12"` in compat already allows it, so the matrix should cover it.

Opened as a PR rather than pushed straight to main so the new 1.13 job proves itself before it becomes a required signal. A local 1.13 run was inconclusive: it died inside `Pkg` (a `Zstd_jll` pkgimage flag mismatch on this machine's first 1.13 run) without reaching any Slate code, so CI on a clean depot is the real test.